### PR TITLE
Related Posts and Style

### DIFF
--- a/cpts/_main.php
+++ b/cpts/_main.php
@@ -8,4 +8,5 @@
 require_once 'actors.php';
 require_once 'characters.php';
 require_once 'shows.php';
+require_once 'related-posts.php';
 require_once 'all-cpts.php';

--- a/cpts/shows.php
+++ b/cpts/shows.php
@@ -432,6 +432,5 @@ SQL;
 // Include Sub Files
 require_once 'shows/calculations.php';
 require_once 'shows/cmb2-metaboxes.php';
-require_once 'shows/related-posts.php';
 
 new LWTV_CPT_Shows();

--- a/plugins/cmb2/lwtv.php
+++ b/plugins/cmb2/lwtv.php
@@ -27,7 +27,7 @@ class LWTV_CMB2 {
 		add_action( 'admin_init', array( $this, 'admin_init' ) );
 		add_action( 'cmb2_admin_init', array( $this, 'favorite_shows_user_profile_metabox' ) );
 
-		$this->icon_taxonomies = array( 'lez_cliches', 'lez_tropes', 'lez_gender', 'lez_sexuality', 'lez_formats', 'lez_genres', 'lez_intersections' );
+		$this->icon_taxonomies = array( 'lez_cliches', 'lez_tropes', 'lez_formats', 'lez_genres', 'lez_intersections' );
 
 		// If we don't have symbolicons, there's not a reason to register the taxonomy box...
 		if ( defined( 'LP_SYMBOLICONS_PATH' ) ) {


### PR DESCRIPTION
## Related Posts

In order to spread more precious SEO Jews all over posts, we're linking 
back to actors if they're mentioned in posts (see Ali Liebert and Yvonne 
Suhor). This will benefit any interviews we do too!

## Style/Icons 

In order to make ongoing maintenance of genders and sexiualites less 
cranky, we're removing custom icons for gender/sexuality/romantic. 
Currently only the following taxonomies have custom icons:

* Cliches, Genres, Intersections, Tropes, TV Stations

That's it.