### PR TITLE
Disable Slack Death Alert Integration

### DIFF
--- a/rest-api/slack.php
+++ b/rest-api/slack.php
@@ -94,8 +94,7 @@ class LWTV_Slack_Integration {
 		$status = self::check_death_status();
 
 		// Bail if the status is false.
-		// || LWTV_DEV_SITE
-		if ( ! $status || LWTV_DEV_SITE || ! defined( LWTV_SLACK_DEATH ) ) {
+		if ( ! $status || LWTV_DEV_SITE ) {
 			return;
 		}
 

--- a/rest-api/slack.php
+++ b/rest-api/slack.php
@@ -21,7 +21,7 @@ class LWTV_Slack_Integration {
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
-		add_action( 'init', array( $this, 'push_slack_death' ) );
+		//add_action( 'init', array( $this, 'push_slack_death' ) );
 	}
 
 	/**


### PR DESCRIPTION
The system is misfiring (only on Mika's personal channel) and runs too often.
Disabling it for now pending further investigation.