### PR TITLE
Of the Day Hashtag Improvements

### DIFF
--- a/rest-api/of-the-day.php
+++ b/rest-api/of-the-day.php
@@ -183,7 +183,10 @@ class LWTV_OTD_JSON {
 					$num_shows = count( $all_shows );
 					$showsmore = ( $num_shows > 1 ) ? ' (plus ' . ( $num_shows - 1 ) . ' more)' : '';
 					$show_post = get_post( $shows_value['show'] );
-					$hashtag   = '#' . implode( '', array_map( 'ucfirst', explode( '-', $show_post->post_name ) ) );
+					$show_name = trim( preg_replace( '~\([^)]+\)~', '', $show_post->post_title ) ); // Remove the (2018) from some shows, using ⌘ as delimiter because shows have all sorts of characters.
+					$show_name = str_replace( ' & ', ' and ', $show_name );
+					$show_name = sanitize_title( $show_name );
+					$hashtag   = '#' . implode( '', array_map( 'ucfirst', explode( '-', $show_name ) ) );
 				}
 				// Set all shows (not used becuase of Sara Lance)
 				if ( '' !== $all_shows && ! empty( $shows_value ) ) {
@@ -201,7 +204,10 @@ class LWTV_OTD_JSON {
 				$return['loved']   = ( get_post_meta( $post_id, 'lezshows_worthit_show_we_love', true ) ) ? 'yes' : 'no';
 				$return['score']   = get_post_meta( $post_id, 'lezshows_the_score', true );
 				$post_data         = get_post( $post_id );
-				$return['hashtag'] = '#' . implode( '', array_map( 'ucfirst', explode( '-', $post_data->post_name ) ) );
+				$show_name         = trim( preg_replace( '~\([^)]+\)~', '', $post_data->post_title ) ); // Remove the (2018) from some shows, using ⌘ as delimiter because shows have all sorts of characters.
+				$show_name         = str_replace( ' & ', ' and ', $show_name );
+				$show_name         = sanitize_title( $show_name );
+				$return['hashtag'] = '#' . implode( '', array_map( 'ucfirst', explode( '-', $show_name ) ) );
 				break;
 		}
 

--- a/rest-api/slack.php
+++ b/rest-api/slack.php
@@ -94,8 +94,7 @@ class LWTV_Slack_Integration {
 		$status = self::check_death_status();
 
 		// Bail if the status is false.
-		// || LWTV_DEV_SITE
-		if ( ! $status || LWTV_DEV_SITE || ! defined( LWTV_SLACK_DEATH ) ) {
+		if ( ! $status || LWTV_DEV_SITE ) {
 			return;
 		}
 

--- a/rest-api/slack.php
+++ b/rest-api/slack.php
@@ -21,7 +21,7 @@ class LWTV_Slack_Integration {
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
-		add_action( 'init', array( $this, 'push_slack_death' ) );
+		//add_action( 'init', array( $this, 'push_slack_death' ) );
 	}
 
 	/**


### PR DESCRIPTION
In order to properly tag shows like Charmed (which have "Charmed" and 
"Charmed (2018)") and shows that have anime AND drama (and thus get 
names like "Foo (Drama)"), the code for hashtagging of-the-days will now 
OMIT text between parenthesis. This should not have an impact on any 
normal shows, and will keep the hashtag reasonable.

#Charmed