### PR TITLE
Affiliate Ads Improvements 

### DIFF
--- a/affiliates/_main.php
+++ b/affiliates/_main.php
@@ -45,9 +45,7 @@ class LWTV_Affilliates {
 			$affiliates = $this->widget_affiliates( 'wide' );
 		}
 
-		$thisad = array_rand( $affiliates );
-
-		$advert = '<!-- BEGIN Affiliate Ads --><div class="affiliate-ads ' . sanitize_html_class( $thisad ) . '"><center>' . $affiliates[ $thisad ] . '</center></div><!-- END Affiliate Ads -->';
+		$advert = '<!-- BEGIN Affiliate Ads --><div class="affiliate-ads"><center>' . $affiliates . '</center></div><!-- END Affiliate Ads -->';
 
 		return $advert;
 	}
@@ -60,36 +58,29 @@ class LWTV_Affilliates {
 	 * @access public
 	 * @return array
 	 */
-	public static function widget_affiliates( $type ) {
+	public static function widget_affiliates( $format ) {
 
-		$affiliates = array(
-			'wide' => array(
-				'facetwp'      => '<a href="https://facetwp.com/?ref=91&campaign=LezPress"><img src="' . plugins_url( 'images/facetwp-300x250.png', __FILE__ ) . '"></a>',
-				'dreamhost'    => '<a href="https://dreamhost.com/dreampress/"><img src="' . plugins_url( 'images/dreamhost-300x250.png', __FILE__ ) . '"></a>',
-				'yikes'        => '<a href="https://www.yikesinc.com"><img src="' . plugins_url( 'images/yikes-300x250.png', __FILE__ ) . '"></a>',
-				'apple'        => '<iframe src="https://widgets.itunes.apple.com/widget.html?c=us&brc=FFFFFF&blc=FFFFFF&trc=FFFFFF&tlc=FFFFFF&d=&t=&m=tvSeason&e=tvSeason&w=250&h=300&ids=&wt=search&partnerId=&affiliate_id=&at=1010lMaT&ct=" frameborder=0 style="overflow-x:hidden;overflow-y:hidden;width:250px;height: 300px;border:0px"></iframe>',
-				'cbs-goodf'    => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/456232/3065/" width="300" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-				'cbs-disco'    => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/447373/3065/" width="300" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-				'cbs-madms'    => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/379711/3065/" width="300" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-				'amazon-prime' => '<iframe src="//rcm-na.amazon-adsystem.com/e/cm?o=1&p=12&l=ur1&category=primemain&banner=028WNSXDMC6H5YDNCB82&f=ifr&lc=pf4&linkID=6c6b73f54a31fb0de8ea99b3c1748ffb&t=lezpress-20&tracking_id=lezpress-20" width="300" height="250" scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0"></iframe>',
-			),
-			'thin' => array(
-				'prime-trial' => '<iframe src="//rcm-na.amazon-adsystem.com/e/cm?o=1&p=14&l=ur1&category=primemain&banner=0GCYTHFZDJTVVMVYTQR2&f=ifr&linkID=f332ccaab48f6b5cc88a95ea0c04800f&t=lezpress-20&tracking_id=lezpress-20" width="160" height="600" scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0"></iframe>',
-				'prime-gift'  => '<iframe src="//rcm-na.amazon-adsystem.com/e/cm?o=1&p=14&l=ur1&category=primegift&banner=0ZWKW7ZFNM91W64BCX02&f=ifr&linkID=5fdaa20b8083037d2e7781f52bccc80c&t=lezpress-20&tracking_id=lezpress-20" width="160" height="600" scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0"></iframe>',
-				'fire-tv'     => '<iframe src="//rcm-na.amazon-adsystem.com/e/cm?o=1&p=14&l=ur1&category=firetv&banner=1823XP89X3YZ6WKZFXR2&f=ifr&linkID=a64601f72d1f1bbf6e40d419b03f2525&t=lezpress-20&tracking_id=lezpress-20" width="160" height="600" scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0"></iframe>',
-				'amazon-gift' => '<iframe src="//rcm-na.amazon-adsystem.com/e/cm?o=1&p=14&l=ur1&category=gift_certificates&banner=0S32YAVKXXKQGNQSSGG2&f=ifr&linkID=03d9bde86e83e638179ddab3d1e10cc2&t=lezpress-20&tracking_id=lezpress-20" width="160" height="600" scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0"></iframe>',
-				'prime-video' => '<iframe src="//rcm-na.amazon-adsystem.com/e/cm?o=1&p=14&l=ur1&category=primeent&banner=0XFKWQVGDFG5VJ2ARBG2&f=ifr&linkID=0fac0d404c29ad18548fd48634f0d1d8&t=lezpress-20&tracking_id=lezpress-20" width="160" height="600" scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0"></iframe>',
-				'cbs-anytime' => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/359934/3065/" width="160" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-				'cbs-stacked' => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/359939/3065/" width="160" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-				'cbs-y_and_r' => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/359947/3065/" width="160" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-				'cbs=livego'  => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/359953/3065/" width="160" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-				'cbs-madames' => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/379709/3065/" width="160" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-				'cbs-stdisco' => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/440478/3065/" width="160" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-				'cbs-gudfite' => '<iframe src="//a.impactradius-go.com/gen-ad-code/1242493/485770/3065/" width="160" height="600" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>',
-			),
+		$id     = get_the_ID();
+		$local  = array(
+			'facetwp'   => '<a href="https://facetwp.com/?ref=91&campaign=LezPress"><img src="' . plugins_url( 'images/facetwp-300x250.png', __FILE__ ) . '"></a>',
+			'dreamhost' => '<a href="https://dreamhost.com/dreampress/"><img src="' . plugins_url( 'images/dreamhost-300x250.png', __FILE__ ) . '"></a>',
+			'yikes'     => '<a href="https://www.yikesinc.com"><img src="' . plugins_url( 'images/yikes-300x250.png', __FILE__ ) . '"></a>',
 		);
+		$number = wp_rand();
 
-		return $affiliates[ $type ];
+		if ( 0 === $number % 2 ) {
+			$advert = self::cbs( $id, 'widget', $format );
+		} elseif ( 0 === $number % 3 ) {
+			$advert = self::amazon( $id, 'widget', $format );
+		} else {
+			if ( 'wide' === $format ) {
+				$advert = $local[ array_rand( $local ) ];
+			} else {
+				$advert = self::cbs( $id, 'widget', $format );
+			}
+		}
+
+		return $advert;
 	}
 
 	/*
@@ -132,18 +123,18 @@ class LWTV_Affilliates {
 
 	/**
 	 * Determine what to call for actors
+	 * This is just random
 	 */
 	public static function actors( $id, $type ) {
-		// Default: Random
 		$return = self::random( $id, $type );
 		return $return;
 	}
 
 	/**
 	 * Determine what to call for characters
+	 * This is just random
 	 */
 	public static function characters( $id, $type ) {
-		// Default: Random
 		$return = self::random( $id, $type );
 		return $return;
 	}
@@ -154,13 +145,8 @@ class LWTV_Affilliates {
 	 */
 	public static function shows( $id, $type ) {
 
-		// Default: Amazon if the transient expired, else Apple.
-		$amazon_transient = get_transient( 'lezwatchtv_amazon_affiliates' );
-		if ( false === $amazon_transient ) {
-			$return = self::amazon( $id, $type );
-		} else {
-			$return = self::apple( $id, $type );
-		}
+		// Default ads are Amazon
+		$return = self::amazon( $id, $type );
 
 		// Show a different show ad depending on things...
 		if ( 'affiliate' === $type ) {
@@ -210,9 +196,7 @@ class LWTV_Affilliates {
 	 */
 	public static function random( $id, $type ) {
 		$number = wp_rand();
-		if ( 0 === $number % 3 ) {
-			$return = self::apple( $id, $type );
-		} elseif ( 0 === $number % 2 ) {
+		if ( 0 === $number % 2 ) {
 			$return = self::cbs( $id, $type );
 		} else {
 			$return = self::amazon( $id, $type );
@@ -223,25 +207,25 @@ class LWTV_Affilliates {
 	/**
 	 * Call Amazon Affilate Data
 	 */
-	public static function amazon( $id, $type ) {
+	public static function amazon( $id, $type, $format = 'wide' ) {
 		require_once 'amazon.php';
-		return LWTV_Affiliate_Amazon::show_ads( $id, $type );
+		return LWTV_Affiliate_Amazon::show_ads( $id, $type, $format );
 	}
 
 	/**
 	 * Call CBS Affilate Data
 	 */
-	public static function cbs( $id, $type ) {
+	public static function cbs( $id, $type, $format = 'wide' ) {
 		require_once 'cbs.php';
-		return LWTV_Affiliate_CBS::show_ads( $id, $type );
+		return LWTV_Affiliate_CBS::show_ads( $id, $type, $format );
 	}
 
 	/**
 	 * Call Apple Affiliate Data
 	 */
-	public static function apple( $id, $type ) {
+	public static function apple( $id, $type, $format = 'wide' ) {
 		require_once 'apple.php';
-		return LWTV_Affiliate_Apple::show_ads( $id, $type );
+		return LWTV_Affiliate_Apple::show_ads( $id, $type, $format );
 	}
 
 	/**

--- a/affiliates/amazon.php
+++ b/affiliates/amazon.php
@@ -17,13 +17,13 @@ class LWTV_Affiliate_Amazon {
 	/**
 	 * Determine what ad to show
 	 */
-	public static function show_ads( $post_id, $type ) {
+	public static function show_ads( $post_id, $type, $format = 'wide' ) {
 
 		// Return the proper output
 		switch ( $type ) {
 			case 'widget':
 			default:
-				$the_ad = self::output_widget( $post_id );
+				$the_ad = self::output_widget( $post_id, $format );
 				break;
 		}
 
@@ -33,167 +33,98 @@ class LWTV_Affiliate_Amazon {
 	/**
 	 * Output widget
 	 */
-	public static function output_widget( $post_id ) {
-		$output = '<center>' . self::bounty( $post_id ) . '</center>';
+	public static function output_widget( $post_id, $format ) {
+		$output = '<center>' . self::bounty( $post_id, $format ) . '</center>';
 		return $output;
 	}
 
 	/**
 	 * Generate a random bounty
 	 */
-	public static function bounty( $post_id ) {
+	public static function bounty( $post_id, $format ) {
 
-		// First let's check if the show is on a network we know....
-		$networks = array(
-			'showtime'     => array(
-				'expires'  => 'ongoing',
-				'banner'   => '1TAG79C3PQ0GFXZ39R82',
-				'linkid'   => '09a6d9595672f638f9f1c23689c40ef5',
-				'category' => 'primevideochannels',
+		$amazon_ads = array(
+			'wide' => array(
+				// 300x250
+				'mrs_maisel'    => array(
+					'banner'   => '01R2KB5YZTMAPA6S78G2',
+					'linkid'   => '0bbbdb2fc387b2ea73aa892e13eba9dd',
+					'category' => 'pivcreative',
+				),
+				'pride'         => array(
+					'banner'   => '1PPVF74KGV3PT8CB9JR2',
+					'linkid'   => 'c696d4f5c174afd46fb8f5bdee9ed9b5',
+					'category' => 'primeent',
+				),
+				'westworld'     => array(
+					'banner'   => '150VYK260KXYESVKAA02',
+					'linkid'   => 'fc4eb97adbbe0e281984a205d79b559a',
+					'category' => 'primevideochannels',
+				),
+				'britbox'       => array(
+					'banner'   => '06V9DZJBZ21E92635K82',
+					'linkid'   => '9d76bd102350dec1360349cd20089b71',
+					'category' => 'primevideochannels',
+				),
+				'gameofthrones' => array(
+					'banner'   => '14CSX9S0TYDSWZT15502',
+					'linkid'   => '94949318c7e79a2fb42cbd909a8318a0',
+					'category' => 'primevideochannels',
+				),
 			),
-			'history'      => array(
-				'expires'  => 'ongoing',
-				'banner'   => '1T7E2FGW5MFJNNJWTAR2',
-				'linkid'   => 'beb013efcdac91c8f30344338a953a97',
-				'category' => 'primevideochannels',
-			),
-			'hbo'          => array(
-				'expires'  => 'ongoing',
-				'banner'   => '1E0AR7ZBTK5HEDE0CM82',
-				'linkid'   => '07178879ba1dd6724b738c8c1069d9de',
-				'category' => 'primevideochannels',
-			),
-			'starz'        => array(
-				'expires'  => 'ongoing',
-				'banner'   => '00G3SH89QT95NWK3CX02',
-				'linkid'   => '1d12f79c1b8dd96406721134df111da6',
-				'category' => 'primevideochannels',
-			),
-			'bbc-america'  => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
-			),
-			'bbc-four'     => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
-			),
-			'bbc-three'    => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
-			),
-			'bbc-two'      => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
-			),
-			'bbc-one'      => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
-			),
-			'bbc-wales'    => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
-			),
-			'itv'          => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
-			),
-			'itv-encore'   => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
-			),
-			'sky-atlantic' => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
-			),
-			'sky-1'        => array(
-				'expires'  => '2018-12-30',
-				'banner'   => '1MFVGHXVB06S23PS7Y82',
-				'linkid'   => 'a99e19307fc515de0e10ed04b7f70c7a',
-				'category' => 'primevideochannels',
+			// 160x600
+			'thin' => array(
+				'mrs_maisel'    => array(
+					'banner'   => '179M3M4HZVSRN11NY602',
+					'linkid'   => 'f3426cf628b26e75a43112ee3c53099d',
+					'category' => 'primeent',
+				),
+				'free_trial'    => array(
+					'banner'   => '161E7D8SBJFWK4M9MNG2',
+					'linkid'   => '20b14469a69f73ba970a4a56ae91f24a',
+					'category' => 'primemain',
+				),
+				'showtime'      => array(
+					'banner'   => '1KDYJTM5G5NPVXW1V2R2',
+					'linkid'   => '93c0604172b79cce3e8341d959d80b78',
+					'category' => 'primevideochannels',
+				),
+				'starz'         => array(
+					'banner'   => '0N482BNAZMAW3F4223G2',
+					'linkid'   => '5d0088e5d0477d7368f2aac6a45d1eef',
+					'category' => 'primevideochannels',
+				),
+				'cbs'           => array(
+					'banner'   => '1RSA96WAH3YGF1HZHCG2',
+					'linkid'   => 'b2a1cc5466874a57f58b9d36baab663c',
+					'category' => 'primevideochannels',
+				),
+				'westworld'     => array(
+					'banner'   => '068G1JD09XF3D3H7QXG2',
+					'linkid'   => '8a9058184c21a6625e8c396eaff6dc1d',
+					'category' => 'primevideochannels',
+				),
+				'britbox'       => array(
+					'banner'   => '062FRX60FAE1CTM89V82',
+					'linkid'   => '26db635a13dc4f3ffef10ed3dbfb6ad4',
+					'category' => 'primevideochannels',
+				),
+				'gameofthrones' => array(
+					'banner'   => '06BB0SBR8G81YR8KW9R2',
+					'linkid'   => '3719c3f34df27cd6ac5e64b4ab55ed4d',
+					'category' => 'primevideochannels',
+				),
 			),
 		);
 
-		// If the network is one of the networks above, let's set that:
-		$stations = get_the_terms( $post_id, 'lez_stations' );
-		if ( $stations && ! is_wp_error( $stations ) ) {
-			foreach ( $stations as $station ) {
-				if ( array_key_exists( $station->slug, $networks ) ) {
-					$expires = $networks[ $station->slug ]['expires'];
-					if ( 'ongoing' === $expires || strtotime( $expires ) >= time() ) {
-						$the_ad = $networks[ $station->slug ];
-					}
-				}
-			}
-		}
+		// Pick a random ad
+		$the_ad = $amazon_ads[ $format ][ array_rand( $amazon_ads[ $format ] ) ];
 
-		// The bounties if nothing else applies
-		$bounties = array(
-			'primeent'  => array(
-				'expires'  => 'ongoing',
-				'banner'   => '1NPA5510D9E368222PR2',
-				'linkid'   => '8a73febb7e83741deca4ec0eb7aa3a1f',
-				'category' => 'primeent',
-			),
-			'anime-dvd' => array(
-				'expires'  => 'ongoing',
-				'banner'   => '0EAD0FBRPQ3YQD8YDM82',
-				'linkid'   => 'a88db93ce5bd7f8a91d7dbf41aa5d75a',
-				'category' => 'dvd',
-			),
-			'primemain' => array(
-				'expires'  => 'ongoing',
-				'banner'   => '028WNSXDMC6H5YDNCB82',
-				'linkid'   => '69b1c93038903293d05110a1c5397f15',
-				'category' => 'primemain',
-			),
-			'firetv'    => array(
-				'expires'  => 'ongoing',
-				'banner'   => '0FXJ4RSQAHG9T84VY2R2',
-				'linkid'   => '7adcc745e35b87b38324232f199497df',
-				'category' => 'amzn_firetv_primepr_0918',
-			),
-			'firetv2'   => array(
-				'expires'  => '2020-10-15',
-				'banner'   => '07Z1A8KKG3NGABM31PG2',
-				'linkid'   => 'bf9112f31ef9ff7bb309e14bad1cc2cd',
-				'category' => 'amzn_firetv_eg_101618',
-			),
-		);
-
-		// If bounty isn't set yet, we need to here
-		if ( ! isset( $the_ad ) ) {
-			// Exclude anything expired
-			foreach ( $bounties as $a_bounty => $value ) {
-				$expires = $value['expires'];
-
-				if ( 'ongoing' === $value['expires'] || strtotime( $expires ) >= time() ) {
-					$bounties[ $a_bounty ] = $value;
-				}
-			}
-			// Pick a random valid bounty
-			$the_ad = $bounties [ array_rand( $bounties ) ];
-		}
+		// Set the size based on the format
+		$size = ( 'wide' === $format ) ? 'width="300" height="250"' : 'width="160" height="600"';
 
 		// Build the Ad
-		$return = '<iframe src="//rcm-na.amazon-adsystem.com/e/cm?o=1&p=12&l=ur1&category=' . $the_ad['category'] . '&banner=' . $the_ad['banner'] . '&f=ifr&linkID=' . $the_ad['linkid'] . '&t=lezpress-20&tracking_id=lezpress-20" width="300" height="250" scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0"></iframe>';
+		$return = '<iframe src="//rcm-na.amazon-adsystem.com/e/cm?o=1&p=12&l=ur1&category=' . $the_ad['category'] . '&banner=' . $the_ad['banner'] . '&f=ifr&linkID=' . $the_ad['linkid'] . '&t=lezpress-20&tracking_id=lezpress-20" ' . $size . ' scrolling="no" border="0" marginwidth="0" style="border:none;" frameborder="0"></iframe>';
 
 		return $return;
 	}

--- a/affiliates/cbs.php
+++ b/affiliates/cbs.php
@@ -6,7 +6,7 @@
 
 
 class LWTV_Affiliate_CBS {
-	public static function show_ads( $post_id, $type ) {
+	public static function show_ads( $post_id, $type, $format = 'wide' ) {
 
 		// Return the proper output
 		switch ( $type ) {
@@ -15,7 +15,7 @@ class LWTV_Affiliate_CBS {
 				break;
 			case 'widget':
 			default:
-				$the_ad = self::output_widget( $post_id );
+				$the_ad = self::output_widget( $post_id, $format );
 				break;
 		}
 
@@ -29,15 +29,17 @@ class LWTV_Affiliate_CBS {
 
 		$slug        = get_post_field( 'post_name', $post_id );
 		$named_array = array(
-			'the-good-wife'                 => '456231',
-			'the-good-fight'                => '455992',
-			'star-trek-the-next-generation' => '366250',
-			'star-trek-deep-space-nine'     => '366250',
-			'star-trek-discovery'           => '440479',
+			'blue-bloods'                   => '379693',
 			'macgyver'                      => '379705',
 			'madam-secretary'               => '379710',
 			'ncis'                          => '379721',
 			'ncis-new-orleans'              => '379721',
+			'star-trek-the-next-generation' => '366250',
+			'star-trek-deep-space-nine'     => '366250',
+			'star-trek-discovery'           => '440479',
+			'the-big-bang-theory'           => '359935',
+			'the-good-wife'                 => '456231',
+			'the-good-fight'                => '455992',
 			'the-young-and-the-restless'    => '359948',
 		);
 
@@ -53,36 +55,57 @@ class LWTV_Affiliate_CBS {
 	/**
 	 * Figure out which ad we really want to show....
 	 */
-	public static function output_widget( $post_id ) {
+	public static function output_widget( $post_id, $format ) {
 
-		// The possible ads: 300 x 250
+		// Wide Ads
 		$named_array = array(
-			'the-good-wife'                 => '456231',
-			'the-good-fight'                => '485771',
-			'star-trek-the-next-generation' => '366250',
-			'star-trek-deep-space-nine'     => '366250',
-			'star-trek-discovery'           => '440479',
-			'macgyver'                      => '379705',
-			'madam-secretary'               => '379710',
-			'ncis'                          => '379721',
-			'ncis-new-orleans'              => '379721',
-			'the-young-and-the-restless'    => '359948',
-			'blue-bloods'                   => '379693',
-			'the-big-bang-theory'           => '359935',
+			// 300x250
+			'wide' => array(
+				'the-good-wife'                 => '456231',
+				'the-good-fight'                => '485771',
+				'star-trek-the-next-generation' => '366250',
+				'star-trek-deep-space-nine'     => '366250',
+				'star-trek-discovery'           => '440479',
+				'macgyver'                      => '379705',
+				'madam-secretary'               => '379710',
+				'ncis'                          => '379721',
+				'ncis-new-orleans'              => '379721',
+				'the-young-and-the-restless'    => '359948',
+				'blue-bloods'                   => '379693',
+				'the-big-bang-theory'           => '359935',
+			),
+			// 160x600
+			'thin' => array(
+				'the-good-wife'                 => '455991',
+				'the-good-fight'                => '455991',
+				'star-trek-the-next-generation' => '366255',
+				'star-trek-deep-space-nine'     => '447371',
+				'star-trek-discovery'           => '567408',
+				'macgyver'                      => '379704',
+				'madam-secretary'               => '379709',
+				'ncis'                          => '359962',
+				'ncis-new-orleans'              => '359962',
+				'the-young-and-the-restless'    => '359947',
+				'blue-bloods'                   => '379692',
+				'the-big-bang-theory'           => '359962',
+			),
 		);
-
-		$generic_array = array( '359935', '359965', '359958', '359954', '359944', '359942', '379693', '440474' );
+		$generic_array = array(
+			'wide' => array( '455992', '572335', '440479', '567410', '379710', '553291' ),
+			'thin' => array( '553290', '455991', '440473', '440478', '447371', '567408', '366255', '455991', '572333' ),
+		);
 
 		$slug = get_post_field( 'post_name', $post_id );
 
-		if ( array_key_exists( $slug, $named_array ) ) {
-			$ad = $named_array[ $slug ];
+		if ( array_key_exists( $slug, $named_array[ $format ] ) ) {
+			$ad = $named_array[ $format ][ $slug ];
 		} else {
-			$ad = $generic_array[ array_rand( $generic_array ) ];
+			$ad = $generic_array[ $format ][ array_rand( $generic_array[ $format ] ) ];
 		}
 
-		// Build the ad
-		$the_ad = '<center><a href="//cbs-allaccess.7eer.net/c/1242493/' . $ad . '/3065"><img src="//a.impactradius-go.com/display-ad/3065-' . $ad . '" border="0" alt="" width="300" height="250"/></a><img height="0" width="0" src="//cbs-allaccess.7eer.net/i/1242493/' . $ad . '/3065" style="position:absolute;visibility:hidden;" border="0" /></center>';
+		$size = ( 'wide' === $format ) ? 'width="300" height="250"' : 'width="160" height="600"';
+
+		$the_ad = '<a href="//cbs-allaccess.7eer.net/c/1242493/' . $ad . '/3065"><img src="//a.impactradius-go.com/display-ad/3065-' . $ad . '" border="0" alt="" ' . $size . ' /></a><img height="0" width="0" src="//cbs-allaccess.7eer.net/i/1242493/' . $ad . '/3065" style="position:absolute;visibility:hidden;" border="0" />';
 
 		return $the_ad;
 

--- a/rest-api/of-the-day.php
+++ b/rest-api/of-the-day.php
@@ -183,7 +183,10 @@ class LWTV_OTD_JSON {
 					$num_shows = count( $all_shows );
 					$showsmore = ( $num_shows > 1 ) ? ' (plus ' . ( $num_shows - 1 ) . ' more)' : '';
 					$show_post = get_post( $shows_value['show'] );
-					$hashtag   = '#' . implode( '', array_map( 'ucfirst', explode( '-', $show_post->post_name ) ) );
+					$show_name = trim( preg_replace( '~\([^)]+\)~', '', $show_post->post_title ) ); // Remove the (2018) from some shows, using ⌘ as delimiter because shows have all sorts of characters.
+					$show_name = str_replace( ' & ', ' and ', $show_name );
+					$show_name = sanitize_title( $show_name );
+					$hashtag   = '#' . implode( '', array_map( 'ucfirst', explode( '-', $show_name ) ) );
 				}
 				// Set all shows (not used becuase of Sara Lance)
 				if ( '' !== $all_shows && ! empty( $shows_value ) ) {
@@ -201,7 +204,10 @@ class LWTV_OTD_JSON {
 				$return['loved']   = ( get_post_meta( $post_id, 'lezshows_worthit_show_we_love', true ) ) ? 'yes' : 'no';
 				$return['score']   = get_post_meta( $post_id, 'lezshows_the_score', true );
 				$post_data         = get_post( $post_id );
-				$return['hashtag'] = '#' . implode( '', array_map( 'ucfirst', explode( '-', $post_data->post_name ) ) );
+				$show_name         = trim( preg_replace( '~\([^)]+\)~', '', $post_data->post_title ) ); // Remove the (2018) from some shows, using ⌘ as delimiter because shows have all sorts of characters.
+				$show_name         = str_replace( ' & ', ' and ', $show_name );
+				$show_name         = sanitize_title( $show_name );
+				$return['hashtag'] = '#' . implode( '', array_map( 'ucfirst', explode( '-', $show_name ) ) );
 				break;
 		}
 

--- a/rest-api/slack.php
+++ b/rest-api/slack.php
@@ -94,8 +94,7 @@ class LWTV_Slack_Integration {
 		$status = self::check_death_status();
 
 		// Bail if the status is false.
-		// || LWTV_DEV_SITE
-		if ( ! $status || LWTV_DEV_SITE || ! defined( LWTV_SLACK_DEATH ) ) {
+		if ( ! $status || LWTV_DEV_SITE ) {
 			return;
 		}
 

--- a/rest-api/slack.php
+++ b/rest-api/slack.php
@@ -21,7 +21,7 @@ class LWTV_Slack_Integration {
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
-		add_action( 'init', array( $this, 'push_slack_death' ) );
+		//add_action( 'init', array( $this, 'push_slack_death' ) );
 	}
 
 	/**


### PR DESCRIPTION
After reviewing affiliate returns for 2018, its evident that some changes need to be taken.

* Pull back on Apple since it's not making any money. (Seriously)
* Update CBS ads to remove all men (Bull, NCIS, etc) unless it's 
relevant to THAT show.
* Update Amazon ads to target our shows a little more.