### PR TITLE
Alexa skills

### DIFF
--- a/affiliates/_main.php
+++ b/affiliates/_main.php
@@ -377,6 +377,9 @@ class LWTV_Affilliates {
 				case 'cartoonnetwork':
 					$name = 'Cartoon Network';
 					break;
+				case 'roosterteeth':
+					$name = 'Roster Teeth';
+					break;
 				case 'showtimeanytime':
 					$name = 'Showtime';
 					break;

--- a/cpts/shows/shows-like-this.php
+++ b/cpts/shows/shows-like-this.php
@@ -21,13 +21,14 @@ class LWTV_Shows_Like_This {
 		add_filter( 'related_posts_by_taxonomy_posts_meta_query', array( $this, 'meta_query' ), 10, 4 );
 		add_filter( 'related_posts_by_taxonomy', array( $this, 'alter_results' ), 10, 4 );
 		add_filter( 'related_posts_by_taxonomy_cache', '__return_true' );
+		add_filter( 'related_posts_by_taxonomy_wp_rest_api', '__return_true' );
 	}
 
 	public static function generate( $show_id ) {
 		$return = '';
 
 		if ( ! empty( $show_id ) && has_filter( 'related_posts_by_taxonomy_posts_meta_query' ) ) {
-			$return = do_shortcode( '[related_posts_by_tax post_id="' . $show_id . '" fields="ids" order="RAND" title="" format="thumbnails" image_size="postloop-img" link_caption="true" posts_per_page="6" columns="0" post_class="similar-shows" taxonomies="lez_tropes,lez_stars,lez_genres,lez_intersections,lez_showtagged"]' );
+			$return = do_shortcode( '[related_posts_by_tax post_id="' . $show_id . '" fields="ids" order="RAND" title="" format="thumbnails" image_size="postloop-img" link_caption="true" posts_per_page="6" columns="0" post_class="similar-shows" taxonomies="lez_country,lez_stars,lez_genres,lez_intersections,lez_showtagged"]' );
 		}
 
 		if ( empty( $return ) ) {
@@ -39,49 +40,49 @@ class LWTV_Shows_Like_This {
 
 	public static function meta_query( $meta_query, $post_id, $taxonomies, $args ) {
 
-		/*
-		 * The $meta_query variable is an array.
-		 *
-		 * If not empty it could be the meta query for post_thumbnails ( key '_thumbnail_id' )
-		 * or some other meta query (from the shortcode or widget).
-		 */
-		$worthit = ( get_post_meta( $post_id, 'lezshows_worthit_rating', true ) ) ? get_post_meta( $post_id, 'lezshows_worthit_rating', true ) : false;
-		$loved   = ( get_post_meta( $post_id, 'lezshows_worthit_show_we_love', true ) ) ? true : false;
-		$score   = ( get_post_meta( $post_id, 'lezshows_the_score', true ) ) ? get_post_meta( $post_id, 'lezshows_the_score', true ) : 10;
+		if ( 'post_type_shows' === get_post_type( $post_id ) ) {
+			/*
+			 * The $meta_query variable is an array.
+			 *
+			 * If not empty it could be the meta query for post_thumbnails ( key '_thumbnail_id' )
+			 * or some other meta query (from the shortcode or widget).
+			 */
+			$worthit = ( get_post_meta( $post_id, 'lezshows_worthit_rating', true ) ) ? get_post_meta( $post_id, 'lezshows_worthit_rating', true ) : false;
+			$loved   = ( get_post_meta( $post_id, 'lezshows_worthit_show_we_love', true ) ) ? true : false;
+			$score   = ( get_post_meta( $post_id, 'lezshows_the_score', true ) ) ? get_post_meta( $post_id, 'lezshows_the_score', true ) : 10;
 
-		// We should match up the worth-it value as well as the score.
-		// After all, some low scores have a thumbs up.
-		if ( false !== $worthit ) {
-			$meta_query[] = array(
-				'key'     => 'lezshows_worthit_rating',
-				'compare' => $worthit,
-			);
-		}
-
-		// If the show is loved, we want to include it here.
-		if ( $loved ) {
-			$meta_query[] = array(
-				'key'     => 'lezshows_worthit_show_we_love',
-				'compare' => 'EXISTS',
-			);
-		}
-
-		// If they're NOT loved, we use the scores for a value.
-		if ( ! $loved ) {
-			// Score: If the score is similar +/- 10
-			if ( $score >= 90 ) {
-				$score_range = array( 80, 100 );
-			} elseif ( $score <= 10 ) {
-				$score_range = array( 10, 30 );
-			} else {
-				$score_range = array( ( $score - 10 ), ( $score + 10 ) );
+			// We should match up the worth-it value as well as the score.
+			// After all, some low scores have a thumbs up.
+			if ( false !== $worthit ) {
+				$meta_query[] = array(
+					'key'     => 'lezshows_worthit_rating',
+					'compare' => $worthit,
+				);
 			}
-			$meta_query[] = array(
-				'key'     => 'lezshows_the_score',
-				'value'   => $score_range,
-				'type'    => 'numeric',
-				'compare' => 'BETWEEN',
-			);
+
+			// If the show is loved, we want to include it here.
+			if ( $loved ) {
+				$meta_query[] = array(
+					'key'     => 'lezshows_worthit_show_we_love',
+					'compare' => 'EXISTS',
+				);
+			} else {
+				// If they're NOT loved, we use the scores for a value.
+				// Score: If the score is similar +/- 10
+				if ( $score >= 90 ) {
+					$score_range = array( 80, 100 );
+				} elseif ( $score <= 10 ) {
+					$score_range = array( 10, 30 );
+				} else {
+					$score_range = array( ( $score - 10 ), ( $score + 10 ) );
+				}
+				$meta_query[] = array(
+					'key'     => 'lezshows_the_score',
+					'value'   => $score_range,
+					'type'    => 'numeric',
+					'compare' => 'BETWEEN',
+				);
+			}
 		}
 
 		return $meta_query;
@@ -98,7 +99,7 @@ class LWTV_Shows_Like_This {
 	 */
 	public function reciprocity( $post_id ) {
 		// If this isn't a show page, bail.
-		if ( ! isset( $post_id ) || 'post_type_shows' !== get_post_type( $post_id ) ) {
+		if ( isset( $post_id ) && 'post_type_shows' !== get_post_type( $post_id ) ) {
 			return;
 		}
 
@@ -163,35 +164,35 @@ class LWTV_Shows_Like_This {
 	 * @return array             The corrected results
 	 */
 	public function alter_results( $results, $post_id, $taxonomies, $args ) {
+		if ( 'post_type_shows' === get_post_type( $post_id ) ) {
+			// Set our base array
+			$add_results = array();
 
-		// Set our base array
-		$add_results = array();
+			// The shortcode only allows post ids or post objects from the query.
+			if ( ! empty( $results ) && empty( $args['fields'] ) ) {
+				$results = wp_list_pluck( $results, 'ID' );
+			}
 
-		// The shortcode only allows post ids or post objects from the query.
-		if ( ! empty( $results ) && empty( $args['fields'] ) ) {
-			$results = wp_list_pluck( $results, 'ID' );
-		}
+			// What MIGHT we be adding:
+			$handpicked  = ( get_post_meta( $post_id, 'lezshows_similar_shows', true ) ) ? wp_parse_id_list( get_post_meta( $post_id, 'lezshows_similar_shows', true ) ) : array();
+			$reciprocity = self::reciprocity( $post_id );
+			$combo_list  = array_merge( $handpicked, $reciprocity );
 
-		// What MIGHT we be adding:
-		$handpicked  = ( get_post_meta( $post_id, 'lezshows_similar_shows', true ) ) ? wp_parse_id_list( get_post_meta( $post_id, 'lezshows_similar_shows', true ) ) : array();
-		$reciprocity = self::reciprocity( $post_id );
-		$combo_list  = array_merge( $handpicked, $reciprocity );
-
-		if ( ! empty( $combo_list ) ) {
-			// For each show, add it to the list ONLY if the show isn't already listed
-			// and if it's published
-			foreach ( $combo_list as $a_show ) {
-				//phpcs:ignore WordPress.PHP.StrictInArray
-				if ( 'publish' === get_post_status( $a_show ) && ! in_array( $a_show, $results ) && ! in_array( $a_show, $add_results ) ) {
-					$add_results[] = $a_show;
+			if ( ! empty( $combo_list ) ) {
+				// For each show, add it to the list ONLY if the show isn't already listed
+				// and if it's published
+				foreach ( $combo_list as $a_show ) {
+					//phpcs:ignore WordPress.PHP.StrictInArray
+					if ( 'publish' === get_post_status( $a_show ) && ! in_array( $a_show, $results ) && ! in_array( $a_show, $add_results ) ) {
+						$add_results[] = $a_show;
+					}
 				}
 			}
+
+			// Add any new posts to the list
+			$results = $add_results + $results;
 		}
 
-		// Add any new posts to the list
-		$results = $add_results + $results;
-
-		// Give 'em back!
 		return $results;
 	}
 }

--- a/features/custom-loops.php
+++ b/features/custom-loops.php
@@ -64,6 +64,10 @@ class LWTV_Loops {
 			$is_queer = 'yes';
 		}
 
+		if ( 'private' === get_post_status( $the_id ) ) {
+			$is_queer = 'no';
+		}
+
 		return $is_queer;
 	}
 

--- a/features/custom-loops.php
+++ b/features/custom-loops.php
@@ -102,6 +102,10 @@ class LWTV_Loops {
 			$is_trans = 'yes';
 		}
 
+		if ( 'private' === get_post_status( $the_id ) ) {
+			$is_trans = 'no';
+		}
+
 		return $is_trans;
 	}
 

--- a/features/debug.php
+++ b/features/debug.php
@@ -198,6 +198,18 @@ class LWTV_Debug {
 				$shows = get_post_meta( $char_id, 'lezchars_show_group', true );
 				if ( ! $shows ) {
 					$problems[] = 'No shows listed.';
+				} else {
+					foreach ( $shows as $each_show ) {
+						if ( ! isset( $each_show['appears'] ) || ! is_array( $each_show['appears'] ) ) {
+							$problems[] = 'No years on air set.';
+						}
+						if ( ! isset( $each_show['type'] ) || '' === $each_show['type'] ) {
+							$problems[] = 'No role set for' . get_the_title( $each_show['show'] ) . '.';
+						}
+						if ( ! isset( $each_show['show'] ) || '' === $each_show['show'] ) {
+							$problems[] = 'No showname set.';
+						}
+					}
 				}
 
 				$actors = get_post_meta( $char_id, 'lezchars_actor', true );

--- a/features/debug.php
+++ b/features/debug.php
@@ -200,8 +200,8 @@ class LWTV_Debug {
 					$problems[] = 'No shows listed.';
 				} else {
 					foreach ( $shows as $each_show ) {
-						if ( ! isset( $each_show['appears'] ) || ! is_array( $each_show['appears'] ) ) {
-							$problems[] = 'No years on air set.';
+						if ( ! is_array( $each_show['appears'] ) ) {
+							$problems[] = 'No years on air set for ' . get_the_title( $each_show['show'] ) . '.';
 						}
 						if ( ! isset( $each_show['type'] ) || '' === $each_show['type'] ) {
 							$problems[] = 'No role set for' . get_the_title( $each_show['show'] ) . '.';

--- a/rest-api/_main.php
+++ b/rest-api/_main.php
@@ -10,6 +10,6 @@ require_once 'bury-your-queers.php';
 require_once 'export-json.php';
 require_once 'imdb.php';
 require_once 'of-the-day.php';
-require_once 'shows-i-like.php';
+require_once 'shows-like-this.php';
 require_once 'stats.php';
 require_once 'what-happened.php';

--- a/rest-api/_main.php
+++ b/rest-api/_main.php
@@ -10,6 +10,6 @@ require_once 'bury-your-queers.php';
 require_once 'export-json.php';
 require_once 'imdb.php';
 require_once 'of-the-day.php';
-require_once 'slack.php';
+require_once 'shows-i-like.php';
 require_once 'stats.php';
 require_once 'what-happened.php';

--- a/rest-api/alexa/byq.php
+++ b/rest-api/alexa/byq.php
@@ -7,7 +7,9 @@ Since Amazon keeps flagging this as 'hate speech' we're rebranding.
 Version: 1.0
 */
 
-if ( ! defined('WPINC' ) ) die;
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
 
 /**
  * class LWTV_Alexa_BYQ
@@ -16,7 +18,7 @@ class LWTV_Alexa_BYQ {
 
 	/**
 	 * How many characters died.
-	 * 
+	 *
 	 * @access public
 	 * @param string $type (default: 'simple')
 	 * @param string $date (default: date('Y'))
@@ -25,9 +27,9 @@ class LWTV_Alexa_BYQ {
 	public function how_many( $type = 'simple' ) {
 
 		// Simple - how many have died total
-		if ( $type == 'simple' ) {
+		if ( 'simple' === $type ) {
 			$data   = LWTV_Stats_JSON::statistics( 'death', 'simple' );
-			$output = 'A total of '. $data['characters']['dead'] .' characters have died on TV.';
+			$output = 'A total of ' . $data['characters']['dead'] . ' characters have died on TV.';
 		} else {
 			$date = $type;
 			// Figure out what date we're working with here...
@@ -43,10 +45,10 @@ class LWTV_Alexa_BYQ {
 				$format   = 'year';
 				$datetime = DateTime::createFromFormat( 'Y', $date );
 			}
-			
+
 			// If it's the future, be smarter than Alexa...
 			if ( $datetime->format( 'Y' ) > date( 'Y' ) ) {
-				$datetime->modify('-1 year');
+				$datetime->modify( '-1 year' );
 			}
 
 			// Calculate death
@@ -56,11 +58,11 @@ class LWTV_Alexa_BYQ {
 					$death_count = $death_query->post_count;
 					break;
 				case 'month':
-					$death_query         = LWTV_Loops::post_meta_and_tax_query( 'post_type_characters', 'lezchars_death_year', $datetime->format( 'Y' ), 'lez_cliches', 'slug', 'dead', 'REGEXP' );
-					$death_list_array    = LWTV_BYQ_JSON::list_of_dead_characters( $death_query );
-					$death_count         = 0;
+					$death_query      = LWTV_Loops::post_meta_and_tax_query( 'post_type_characters', 'lezchars_death_year', $datetime->format( 'Y' ), 'lez_cliches', 'slug', 'dead', 'REGEXP' );
+					$death_list_array = LWTV_BYQ_JSON::list_of_dead_characters( $death_query );
+					$death_count      = 0;
 					foreach ( $death_list_array as $the_dead ) {
-						if ( $datetime->format( 'm' ) == date( 'm' , $the_dead['died'] ) ) {
+						if ( $datetime->format( 'm' ) === date( 'm', $the_dead['died'] ) ) {
 							$death_count++;
 						}
 					}
@@ -75,6 +77,7 @@ class LWTV_Alexa_BYQ {
 
 			$dead = 'no one died! I\'m surprised too.';
 			if ( $death_count > 0 ) {
+				// translators: %s number of characters
 				$dead = sprintf( _n( '%s character', '%s characters', $death_count ), $death_count );
 			}
 
@@ -87,7 +90,7 @@ class LWTV_Alexa_BYQ {
 					$intro = 'In ' . $datetime->format( 'F Y' );
 					break;
 				default:
-					$intro  = ( $datetime->format( 'Y' ) == date( 'Y' ) )? 'So far in ' : 'In ';
+					$intro  = ( $datetime->format( 'Y' ) === date( 'Y' ) ) ? 'So far in ' : 'In ';
 					$intro .= $datetime->format( 'Y' );
 					break;
 			}
@@ -101,25 +104,27 @@ class LWTV_Alexa_BYQ {
 	public function on_a_day( $date = false ) {
 
 		// Make sure we have a default timestamp
-		$timestamp  = ( strtotime( $date ) == false )? time() : strtotime( $date ) ;
+		$timestamp = ( strtotime( $date ) === false ) ? time() : strtotime( $date );
 
 		// Figure out who died on a day...
 		$this_day = date( 'm-d', $timestamp );
 		$data     = LWTV_BYQ_JSON::on_this_day( $this_day );
-		$count    = ( key( $data ) == 'none' )? 0 : count( $data ) ;
+		$count    = ( 'none' === key( $data ) ) ? 0 : count( $data );
 		$how_many = 'No characters died';
 		$the_dead = '';
 		if ( $count > 0 ) {
 			$how_many  = $count . ' ' . _n( 'character', 'characters', $count ) . ' died';
 			$deadcount = 1;
 			foreach ( $data as $dead_character ) {
-				if ( $deadcount == $count && $count !== 1 ) $the_dead .= 'And ';
+				if ( $deadcount === $count && 1 !== $count ) {
+					$the_dead .= 'And ';
+				}
 				$the_dead .= $dead_character['name'] . ' in ' . $dead_character['died'] . '. ';
 				$deadcount++;
 			}
 		}
-		$output = $how_many . ' on '. date('F jS', $timestamp ) . '. ' . $the_dead;
-		
+		$output = $how_many . ' on ' . date( 'F jS', $timestamp ) . '. ' . $the_dead;
+
 		return $output;
 	}
 

--- a/rest-api/alexa/byq.php
+++ b/rest-api/alexa/byq.php
@@ -75,7 +75,7 @@ class LWTV_Alexa_BYQ {
 					$death_count = 0;
 			}
 
-			$dead = 'no one died! I\'m surprised too.';
+			$dead = 'no one died!';
 			if ( $death_count > 0 ) {
 				// translators: %s number of characters
 				$dead = sprintf( _n( '%s character', '%s characters', $death_count ), $death_count );
@@ -110,7 +110,7 @@ class LWTV_Alexa_BYQ {
 		$this_day = date( 'm-d', $timestamp );
 		$data     = LWTV_BYQ_JSON::on_this_day( $this_day );
 		$count    = ( 'none' === key( $data ) ) ? 0 : count( $data );
-		$how_many = 'No characters died';
+		$how_many = 'No characters died ';
 		$the_dead = '';
 		if ( $count > 0 ) {
 			$how_many  = $count . ' ' . _n( 'character', 'characters', $count ) . ' died';

--- a/rest-api/alexa/flash-brief.php
+++ b/rest-api/alexa/flash-brief.php
@@ -8,7 +8,9 @@ special version.
 Version: 1.0
 */
 
-if ( ! defined('WPINC' ) ) die;
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
 
 /**
  * class LWTV_Alexa_Flash_Brief
@@ -26,7 +28,7 @@ class LWTV_Alexa_Flash_Brief {
 		if ( $queery->have_posts() ) {
 			while ( $queery->have_posts() ) {
 				$queery->the_post();
-				$response = array(
+				$response    = array(
 					'uid'            => get_the_permalink(),
 					'updateDate'     => get_post_modified_time( 'Y-m-d\TH:i:s.\0\Z' ),
 					'titleText'      => get_the_title(),

--- a/rest-api/alexa/newest.php
+++ b/rest-api/alexa/newest.php
@@ -7,7 +7,9 @@ Generate the newest shows or characters (or deaths)
 Version: 1.0
 */
 
-if ( ! defined( 'WPINC' ) ) die;
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
 
 /**
  * class LWTV_Alexa_Newest
@@ -41,7 +43,7 @@ class LWTV_Alexa_Newest {
 			'post_type'      => 'post_type_characters',
 			'posts_per_page' => '1',
 			'orderby'        => 'date',
-			'order'          => 'DESC'
+			'order'          => 'DESC',
 		);
 
 		$queery = new WP_Query( $post_args );

--- a/rest-api/alexa/similar-show.php
+++ b/rest-api/alexa/similar-show.php
@@ -1,0 +1,117 @@
+<?php
+/*
+Description: REST-API - Alexa Skills - Similar Shows
+
+This is how we figure out what shows are like other shows
+
+Version: 1.0
+*/
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * class LWTV_Alexa_Shows
+ */
+class LWTV_Alexa_Shows {
+
+	/**
+	 * Who is NAME? Let's find out...
+	 *
+	 * @access public
+	 * @return string
+	 */
+	public function similar_to( $name = false ) {
+
+		$failure = 'I\'m sorry, I don\'t recognize that show. Please try again, asking me about a specific telelvision show.';
+		if ( ! $name ) {
+			return $failure;
+		}
+
+		// Get the actor array:
+		$results = self::search_this( $name );
+		$output  = '';
+
+		if ( ! isset( $results ) || ! $results ) {
+			$output = 'I can\'t find an television show by that name. That may mean I have no recorded characters for that show.';
+		} else {
+			if ( count( $results ) > 1 ) {
+				$output = 'I found more than one television show matching that name. ';
+			}
+
+			foreach ( $results as $show ) {
+				$similar = LWTV_Shows_Like_This_JSON::similar_show( $show );
+				foreach ( $similar['related'] as $a_show ) {
+					$related_array[] = $a_show['title'];
+				}
+				if ( isset( $related_array ) ) {
+					if ( count( $related_array ) > 1 ) {
+						$last_element = array_pop( $related_array );
+						array_push( $related_array, 'and ' . $last_element );
+					}
+					$related_string = implode( ', ', $related_array );
+				}
+
+				$output .= 'If you like ' . $show . ' then you may also like these shows. ' . $related_string . '. ';
+			}
+		}
+
+		return $output;
+	}
+
+	/**
+	 * search_this function.
+	 *
+	 * @access public
+	 * @param mixed $name (default: = false)
+	 * @return void
+	 */
+	public function search_this( $name = false ) {
+
+		if ( ! $name ) {
+			return false;
+		}
+
+		// Remove <!--fwp-loop--> from output
+		// phpcs:ignore
+		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) { return false; }, 10, 2 );
+
+		$args = array(
+			's'              => $name,
+			'post_type'      => 'post_type_shows',
+			'post_status'    => 'publish',
+			'posts_per_page' => 5,
+		);
+
+		$the_show = new WP_Query( $args );
+		$show_arr = array();
+
+		if ( $the_show->have_posts() ) {
+
+			while ( $the_show->have_posts() ) {
+
+				$the_show->the_post();
+
+				// Check display name...
+				// If it matches, we'll go
+				$title_array = explode( ' ', get_the_title() );
+				$short_name  = current( $title_array ) . end( $title_array );
+
+				if ( strtolower( get_the_title() ) === strtolower( $name ) || strtolower( $short_name ) === strtolower( $name ) ) {
+					$show_arr[] = $the_show->post_name();
+				}
+			}
+			wp_reset_postdata();
+		}
+
+		if ( ! isset( $show_arr ) ) {
+			return false;
+		}
+
+		return $show_arr;
+	}
+
+}
+
+new LWTV_Alexa_Shows();

--- a/rest-api/alexa/this-year.php
+++ b/rest-api/alexa/this-year.php
@@ -7,7 +7,9 @@ Gives you an idea how this year is going...
 Version: 1.0
 */
 
-if ( ! defined('WPINC' ) ) die;
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
 
 /**
  * class LWTV_Alexa_This_Year
@@ -58,9 +60,10 @@ class LWTV_Alexa_This_Year {
 
 		// Language of Death
 		$dead = 'Miraculously, no characters died';
-			if ( $count_array['dead'] > 0 ) {
-				$dead = sprintf( _n( '%s character died', '%s characters died', $count_array['dead'] ), $count_array['dead'] );
-			}
+		if ( $count_array['dead'] > 0 ) {
+			// Translators: %s is number of dead characters
+			$dead = sprintf( _n( '%s character died', '%s characters died', $count_array['dead'] ), $count_array['dead'] );
+		}
 		// Now to personalize it...
 		if ( $count_array['dead'] > 20 ) {
 			$dead = 'Disturbingly, ' . $dead;
@@ -71,9 +74,14 @@ class LWTV_Alexa_This_Year {
 		}
 
 		// Language of shows, characters, and posts
-		$characters = ( $count_array['characters'] == 0 )? 'no characters' : sprintf( _n( '%s character', '%s characters', $count_array['characters'] ), $count_array['characters'] );
-		$shows      = ( $count_array['shows'] == 0 )? 'no shows' : sprintf( _n( '%s show', '%s shows', $count_array['shows'] ), $count_array['shows'] );
-		$posts      = ( $count_array['posts'] == 0 )? 'no posts' : sprintf( _n( '%s post', '%s posts', $count_array['posts'] ), $count_array['posts'] );
+		// Translators: %s is number of dead characters
+		$characters = ( 0 === $count_array['characters'] ) ? 'no characters' : sprintf( _n( '%s character', '%s characters', $count_array['characters'] ), $count_array['characters'] );
+
+		// Translators: %s is number of dead characters
+		$shows = ( 0 === $count_array['shows'] ) ? 'no shows' : sprintf( _n( '%s show', '%s shows', $count_array['shows'] ), $count_array['shows'] );
+
+		// Translators: %s is number of dead characters
+		$posts = ( 0 === $count_array['posts'] ) ? 'no posts' : sprintf( _n( '%s post', '%s posts', $count_array['posts'] ), $count_array['posts'] );
 
 		// Language sucks...
 		if ( $today ) {
@@ -87,20 +95,27 @@ class LWTV_Alexa_This_Year {
 					$intro = 'In ' . $datetime->format( 'F Y' );
 					break;
 				default:
-					$intro  = ( $datetime->format( 'Y' ) == date( 'Y' ) ) ? 'So far, in ' : 'In ';
+					$intro  = ( $datetime->format( 'Y' ) === date( 'Y' ) ) ? 'So far, in ' : 'In ';
 					$intro .= $datetime->format( 'Y' );
 					break;
 			}
 		}
 
 		// This Year On Air information:
-		$on_the_air = ( $count_array['on_air']['current'] == 0 ) ? 'no shows' : sprintf( _n( '%s show', '%s shows', $count_array['on_air']['current'] ), $count_array['on_air']['current'] );
-		$started    = ( $count_array['on_air']['started'] == 0 ) ? 'no shows' : sprintf( _n( '%s show', '%s shows', $count_array['on_air']['started'] ), $count_array['on_air']['started'] );
-		$ended      = ( $count_array['on_air']['ended'] == 0 ) ? 'no shows' : sprintf( _n( '%s show', '%s shows', $count_array['on_air']['ended'] ), $count_array['on_air']['ended'] );
+		// Translators: %s is number of shows
+		$on_the_air = ( 0 === $count_array['on_air']['current'] ) ? 'no shows' : sprintf( _n( '%s show', '%s shows', $count_array['on_air']['current'] ), $count_array['on_air']['current'] );
+
+		// Translators: %s is number of shows
+		$started = ( 0 === $count_array['on_air']['started'] ) ? 'no shows' : sprintf( _n( '%s show', '%s shows', $count_array['on_air']['started'] ), $count_array['on_air']['started'] );
+
+		// Translators: %s is number of shows
+		$ended = ( 0 === $count_array['on_air']['ended'] ) ? 'no shows' : sprintf( _n( '%s show', '%s shows', $count_array['on_air']['ended'] ), $count_array['on_air']['ended'] );
 
 		// This Year DEATH information
 		$death_this_year_query = LWTV_Loops::post_meta_and_tax_query( 'post_type_characters', 'lezchars_death_year', $datetime->format( 'Y' ), 'lez_cliches', 'slug', 'dead', 'REGEXP' );
-		$death_this_year       = ( 0 === $death_this_year_query->post_count ) ? 'no characters died' : sprintf( _n( '%s character died', '%s characters died', $death_this_year_query->post_count ), $death_this_year_query->post_count );
+
+		// Translators: %s is number of dead characters
+		$death_this_year = ( 0 === $death_this_year_query->post_count ) ? 'no characters died' : sprintf( _n( '%s character died', '%s characters died', $death_this_year_query->post_count ), $death_this_year_query->post_count );
 
 		// Conclusion
 		if ( $datetime->format( 'Y' ) > 2013 ) {

--- a/rest-api/alexa/who-are-you.php
+++ b/rest-api/alexa/who-are-you.php
@@ -7,7 +7,9 @@ This is how we figure out who the fuck an actor is
 Version: 1.0
 */
 
-if ( ! defined('WPINC' ) ) die;
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
 
 /**
  * class LWTV_Alexa_Newest
@@ -16,29 +18,32 @@ class LWTV_Alexa_Who {
 
 	/**
 	 * Who is NAME? Let's find out...
-	 * 
+	 *
 	 * @access public
 	 * @return string
 	 */
 	public function who_is( $name = false ) {
 
 		$failure = 'I\'m sorry, I don\'t recognize that name. Please try again, asking me who a specific actor is.';
-		if ( !$name ) return $failure;
+		if ( ! $name ) {
+			return $failure;
+		}
 
 		// Get the actor array:
 		$results = self::search_this( $name );
 
-		if ( !isset( $results ) || !$results ) {
+		if ( ! isset( $results ) || ! $results ) {
 			$output = 'I can\'t find an actor who has played a queer character by that name.';
 		} else {
-			if ( count ( $results ) > 1 ) {
+			if ( count( $results ) > 1 ) {
 				$output = 'I found more than one actor matching that name. ';
 			}
 
 			foreach ( $results as $actor ) {
-				$queer      = ( $actor[ 'is_queer' ] )? 'a queer actor' : 'an actor';
-				$characters = ( $actor[ 'characters' ] == 0 )? 'no queer characters' : sprintf( _n( '%s queer character', '%s queer characters', $actor[ 'characters' ] ), $actor[ 'characters' ] );
-				$output .= $actor[ 'name' ] . ' is ' . $queer . ' who has played ' . $characters . ' on television. ';
+				$queer = ( $actor['is_queer'] ) ? 'a queer actor' : 'an actor';
+				// translators: %s is the number of queer character
+				$characters = ( 0 === $actor['characters'] ) ? 'no queer characters' : sprintf( _n( '%s queer character', '%s queer characters', $actor['characters'] ), $actor['characters'] );
+				$output    .= $actor['name'] . ' is ' . $queer . ' who has played ' . $characters . ' on television. ';
 			}
 		}
 
@@ -48,7 +53,7 @@ class LWTV_Alexa_Who {
 
 	/**
 	 * is_gay function.
-	 * 
+	 *
 	 * @access public
 	 * @param bool $name (default: false)
 	 * @return void
@@ -56,20 +61,22 @@ class LWTV_Alexa_Who {
 	public function is_gay( $name = false ) {
 
 		$failure = 'I\'m sorry, I don\'t recognize that name. Please try again, asking me who a specific actor is.';
-		if ( !$name ) return $failure;
+		if ( ! $name ) {
+			return $failure;
+		}
 
 		// Get the actor array:
 		$results = self::search_this( $name );
 
 		if ( isset( $results ) ) {
-			if ( count ( $results ) > 1 ) {
+			if ( count( $results ) > 1 ) {
 				$output = 'I found more than one actor matching that name. ';
 			}
 
 			foreach ( $results as $actor ) {
-				$queer = ( $actor[ 'is_queer' ] )? 'is queer' : 'is not queer';
-				
-				switch ( $actor[ 'gender' ] ) {
+				$queer = ( $actor['is_queer'] ) ? 'is queer' : 'is not queer';
+
+				switch ( $actor['gender'] ) {
 					case 'Cis Woman':
 					case 'Trans Woman':
 						$pronoun = 'She identifies';
@@ -81,9 +88,8 @@ class LWTV_Alexa_Who {
 					default:
 						$pronoun = 'They identify';
 				}
-				
-				
-				$output .= $actor[ 'name' ] . ' ' . $queer . '. ' . $pronoun . ' as a ' . strtolower( $actor[ 'sexuality' ] ) . ' ' . strtolower( $actor[ 'gender' ] ) . '.';
+
+				$output .= $actor['name'] . ' ' . $queer . '. ' . $pronoun . ' as a ' . strtolower( $actor['sexuality'] ) . ' ' . strtolower( $actor['gender'] ) . '.';
 			}
 		} else {
 			$output = 'I can\'t find an actor who has played a character by that name.';
@@ -94,16 +100,19 @@ class LWTV_Alexa_Who {
 
 	/**
 	 * search_this function.
-	 * 
+	 *
 	 * @access public
 	 * @param mixed $name (default: = false)
 	 * @return void
 	 */
 	public function search_this( $name = false ) {
 
-		if ( !$name ) return false;
+		if ( ! $name ) {
+			return false;
+		}
 
 		// Remove <!--fwp-loop--> from output
+		// phpcs:ignore
 		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) { return false; }, 10, 2 );
 
 		$args = array(
@@ -126,32 +135,33 @@ class LWTV_Alexa_Who {
 				// If it matches, we'll go
 				$title_array = explode( ' ', get_the_title() );
 				$short_name  = current( $title_array ) . end( $title_array );
-				
-				if ( strtolower( get_the_title() ) == strtolower( $name ) || strtolower( $short_name ) == strtolower( $name ) ) {
+
+				if ( strtolower( get_the_title() ) === strtolower( $name ) || strtolower( $short_name ) === strtolower( $name ) ) {
 
 					// Figure out the age
 					// Use it like: $age->format( '%Y years old' );
-					$end   = ( get_post_meta( get_the_ID(), 'lezactors_death', true ) )? new DateTime( get_post_meta( get_the_ID(), 'lezactors_death', true ) ) : new DateTime() ;
-					$start = ( get_post_meta( get_the_ID(), 'lezactors_birth', true ) )? new DateTime( get_post_meta( get_the_ID(), 'lezactors_birth', true ) ) : false;
+					$end   = ( get_post_meta( get_the_ID(), 'lezactors_death', true ) ) ? new DateTime( get_post_meta( get_the_ID(), 'lezactors_death', true ) ) : new DateTime();
+					$start = ( get_post_meta( get_the_ID(), 'lezactors_birth', true ) ) ? new DateTime( get_post_meta( get_the_ID(), 'lezactors_birth', true ) ) : false;
 					$age   = false;
-					if ( $start !== false ) {
+					if ( false !== $start ) {
 						$age = $start->diff( $end );
 					}
-	
-					$gender = $sexuality = array();
+
+					$gender       = array();
+					$sexuality    = array();
 					$gender_terms = get_the_terms( get_the_ID(), 'lez_actor_gender', true );
 					if ( $gender_terms && ! is_wp_error( $gender_terms ) ) {
-						foreach( $gender_terms as $gender_term ) {
+						foreach ( $gender_terms as $gender_term ) {
 							$gender[] = $gender_term->name;
 						}
 					}
-					$sexuality_terms = get_the_terms( $the_ID, 'lez_actor_sexuality', true );
+					$sexuality_terms = get_the_terms( get_the_ID(), 'lez_actor_sexuality', true );
 					if ( $sexuality_terms && ! is_wp_error( $sexuality_terms ) ) {
-						foreach( $sexuality_terms as $sexuality_term ) {
+						foreach ( $sexuality_terms as $sexuality_term ) {
 							$sexuality[] = $sexuality_term->name;
 						}
 					}
-	
+
 					$actor_arr[ get_post_field( 'post_name' ) ] = array(
 						'name'       => get_the_title(),
 						'characters' => get_post_meta( get_the_ID(), 'lezactors_char_count', true ),
@@ -166,7 +176,7 @@ class LWTV_Alexa_Who {
 			wp_reset_postdata();
 		}
 
-		if ( !isset( $actor_arr ) ) {
+		if ( ! isset( $actor_arr ) ) {
 			return false;
 		}
 

--- a/rest-api/bury-your-queers.php
+++ b/rest-api/bury-your-queers.php
@@ -228,7 +228,7 @@ class LWTV_BYQ_JSON {
 			$timestamp = time();
 			$dt        = new DateTime( 'now', new DateTimeZone( $tz ) ); //first argument "must" be a string
 			$dt->setTimestamp( $timestamp ); //adjust the object to correct timestamp
-			$this_day  = $dt->format( 'm-d' );
+			$this_day = $dt->format( 'm-d' );
 		}
 
 		// Default to JSON (i.e. what the plugin uses)

--- a/rest-api/imdb.php
+++ b/rest-api/imdb.php
@@ -32,14 +32,22 @@ class LWTV_IMDb_JSON {
 	 *   - /lwtv/v1/imdb/
 	 */
 	public function rest_api_init() {
-		register_rest_route( 'lwtv/v1', '/imdb/', array(
-			'methods' => 'GET',
-			'callback' => array( $this, 'imdb_rest_api_callback' ),
-		) );
-		register_rest_route( 'lwtv/v1', '/imdb/(?P<id>[a-zA-Z0-9-]+)', array(
-			'methods' => 'GET',
-			'callback' => array( $this, 'imdb_rest_api_callback' ),
-		) );
+		register_rest_route(
+			'lwtv/v1',
+			'/imdb/',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'imdb_rest_api_callback' ),
+			)
+		);
+		register_rest_route(
+			'lwtv/v1',
+			'/imdb/(?P<id>[a-zA-Z0-9-]+)',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'imdb_rest_api_callback' ),
+			)
+		);
 	}
 
 	/**
@@ -98,7 +106,7 @@ class LWTV_IMDb_JSON {
 		}
 		wp_reset_postdata();
 
-		// Base Array:
+		// Base Array.
 		$array = array(
 			'id'   => $post_id,
 			'name' => get_the_title( $post_id ),

--- a/rest-api/of-the-day.php
+++ b/rest-api/of-the-day.php
@@ -254,7 +254,7 @@ class LWTV_OTD_JSON {
 						'compare' => 'LIKE',
 					),
 				);
-				$tax_query_array = self::character_awareness( $date );
+				$tax_query_array  = self::character_awareness( $date );
 				break;
 			case 'show':
 				$meta_query_array = array(

--- a/rest-api/shows-i-like.php
+++ b/rest-api/shows-i-like.php
@@ -1,0 +1,96 @@
+<?php
+/*
+Description: REST-API - Shows I Like
+
+Calls the
+
+Version: 1.0.0
+*/
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+/**
+ * class LWTV_Shows_I_Like_JSON
+ *
+ * The basic constructor class that will set up our JSON API.
+ */
+class LWTV_Shows_I_Like_JSON {
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
+	}
+
+	/**
+	 * Rest API init
+	 *
+	 * Creates callbacks
+	 *   - /lwtv/v1/of-the-day/
+	 */
+	public static function rest_api_init() {
+
+		register_rest_route(
+			'lwtv/v1',
+			'/similar-shows/',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'rest_api_callback' ),
+			)
+		);
+		register_rest_route(
+			'lwtv/v1',
+			'/similar-shpws/(?P<show>[a-zA-Z]+)',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'rest_api_callback' ),
+			)
+		);
+	}
+
+	/**
+	 * Rest API Callback
+	 */
+	public static function rest_api_callback( $data ) {
+		$params = $data->get_params();
+		$show   = ( isset( $params['show'] ) && '' !== $params['show'] ) ? sanitize_title_for_query( $params['show'] ) : 'unknown';
+
+		$response = $this->similar_show( $show );
+		return $response;
+	}
+
+	/*
+	 * Similar Show function
+	 */
+	public static function similar_show( $show = 'unknown' ) {
+
+		$return = false;
+
+		if ( 'unknown' !== $show ) {
+			$show_obj = get_page_by_path( $show, OBJECT, 'post_type_shows' );
+			if ( $show_obj ) {
+				$show_id = $show_obj->ID;
+
+				$response = wp_remote_get( home_url() . '/wp-json/related-posts-by-taxonomy/v1/posts/' . $show_id . '?fields=ids&taxonomies=lez_country,lez_stars,lez_genres,lez_intersections,lez_showtagged' );
+				if ( is_array( $response ) ) {
+					$return = array(
+						'post_id' => $show_id,
+						'slug'    => $show,
+						'related' => $response['body'],
+					);
+				}
+			}
+		}
+
+		if ( ! $return ) {
+			return new WP_Error( 'invalid_show', 'Invalid show name.', array( 'status' => 404 ) );
+		} else {
+			return $return;
+		}
+	}
+}
+
+new LWTV_Shows_I_Like_JSON();

--- a/rest-api/shows-like-this.php
+++ b/rest-api/shows-like-this.php
@@ -1,6 +1,6 @@
 <?php
 /*
-Description: REST-API - Shows I Like
+Description: REST-API - Shows Like This
 
 Calls the
 
@@ -12,11 +12,11 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 /**
- * class LWTV_Shows_I_Like_JSON
+ * class LWTV_Shows_Like_This_JSON
  *
  * The basic constructor class that will set up our JSON API.
  */
-class LWTV_Shows_I_Like_JSON {
+class LWTV_Shows_Like_This_JSON {
 
 	/**
 	 * Constructor
@@ -43,7 +43,7 @@ class LWTV_Shows_I_Like_JSON {
 		);
 		register_rest_route(
 			'lwtv/v1',
-			'/similar-shpws/(?P<show>[a-zA-Z]+)',
+			'/similar-shows/(?P<show>[a-zA-Z]+)',
 			array(
 				'methods'  => 'GET',
 				'callback' => array( $this, 'rest_api_callback' ),
@@ -76,10 +76,22 @@ class LWTV_Shows_I_Like_JSON {
 
 				$response = wp_remote_get( home_url() . '/wp-json/related-posts-by-taxonomy/v1/posts/' . $show_id . '?fields=ids&taxonomies=lez_country,lez_stars,lez_genres,lez_intersections,lez_showtagged' );
 				if ( is_array( $response ) ) {
+					$rel_shows = json_decode( wp_remote_retrieve_body( $response ), true );
+					$related   = array();
+
+					foreach ( $rel_shows['posts'] as $each_show ) {
+						$related[] = array(
+							'post_id' => $each_show,
+							'title'   => get_the_title( $each_show ),
+							'url'     => get_permalink( $each_show ),
+						);
+					}
+
 					$return = array(
 						'post_id' => $show_id,
-						'slug'    => $show,
-						'related' => $response['body'],
+						'title'   => get_the_title( $show_id ),
+						'url'     => get_permalink( $show_id ),
+						'related' => $related,
 					);
 				}
 			}
@@ -93,4 +105,4 @@ class LWTV_Shows_I_Like_JSON {
 	}
 }
 
-new LWTV_Shows_I_Like_JSON();
+new LWTV_Shows_Like_This_JSON();

--- a/rest-api/slack.php
+++ b/rest-api/slack.php
@@ -21,7 +21,7 @@ class LWTV_Slack_Integration {
 	 */
 	public function __construct() {
 		add_action( 'rest_api_init', array( $this, 'rest_api_init' ) );
-		//add_action( 'init', array( $this, 'push_slack_death' ) );
+		add_action( 'init', array( $this, 'push_slack_death' ) );
 	}
 
 	/**

--- a/rest-api/stats.php
+++ b/rest-api/stats.php
@@ -41,37 +41,53 @@ class LWTV_Stats_JSON {
 	public function rest_api_init() {
 
 		// Basic Stats
-		register_rest_route( 'lwtv/v1', '/stats/', array(
-			'methods'  => 'GET',
-			'callback' => array(
-				$this,
-				'stats_rest_api_callback',
-			),
-		) );
+		register_rest_route(
+			'lwtv/v1',
+			'/stats/',
+			array(
+				'methods'  => 'GET',
+				'callback' => array(
+					$this,
+					'stats_rest_api_callback',
+				),
+			)
+		);
 
 		// Stat Types
-		register_rest_route( 'lwtv/v1', '/stats/(?P<type>[a-zA-Z.\-]+)', array(
-			'methods'  => 'GET',
-			'callback' => array(
-				$this,
-				'stats_rest_api_callback',
-			),
-		) );
+		register_rest_route(
+			'lwtv/v1',
+			'/stats/(?P<type>[a-zA-Z.\-]+)',
+			array(
+				'methods'  => 'GET',
+				'callback' => array(
+					$this,
+					'stats_rest_api_callback',
+				),
+			)
+		);
 
 		// Stat Types and Format
-		register_rest_route( 'lwtv/v1', '/stats/(?P<type>[a-zA-Z]+)/(?P<format>[a-zA-Z]+)', array(
-			'methods'  => 'GET',
-			'callback' => array(
-				$this,
-				'stats_rest_api_callback',
-			),
-		) );
+		register_rest_route(
+			'lwtv/v1',
+			'/stats/(?P<type>[a-zA-Z]+)/(?P<format>[a-zA-Z]+)',
+			array(
+				'methods'  => 'GET',
+				'callback' => array(
+					$this,
+					'stats_rest_api_callback',
+				),
+			)
+		);
 
 		// Stat Types and Format AND PER PAGE
-		register_rest_route( 'lwtv/v1', '/stats/(?P<type>[a-zA-Z]+)/(?P<format>[a-zA-Z]+)/(?P<page>[0-9.\-]+)', array(
-			'methods'  => 'GET',
-			'callback' => array( $this, 'stats_rest_api_callback' ),
-		) );
+		register_rest_route(
+			'lwtv/v1',
+			'/stats/(?P<type>[a-zA-Z]+)/(?P<format>[a-zA-Z]+)/(?P<page>[0-9.\-]+)',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'stats_rest_api_callback' ),
+			)
+		);
 
 	}
 
@@ -100,9 +116,8 @@ class LWTV_Stats_JSON {
 	public static function statistics( $stat_type = 'characters', $format = 'simple', $page = 1 ) {
 
 		// Remove <!--fwp-loop--> from output
-		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) {
-			return false;
-		}, 10, 2 );
+		// phpcs:ignore
+		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) { return false; }, 10, 2 );
 
 		// Valid Data
 		$valid_type   = array( 'characters', 'actors', 'shows', 'death', 'first-year', 'stations', 'nations' );
@@ -160,9 +175,8 @@ class LWTV_Stats_JSON {
 	public static function get_actors( $format = 'simple', $page = 1 ) {
 
 		// Remove <!--fwp-loop--> from output
-		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) {
-			return false;
-		}, 10, 2 );
+		// phpcs:ignore
+		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) { return false; }, 10, 2 );
 
 		// Validate Data
 		$valid_format = array( 'simple', 'complex', 'sexuality', 'gender', 'queer-irl', 'id' );
@@ -230,9 +244,8 @@ class LWTV_Stats_JSON {
 	public static function get_characters( $format = 'simple', $page = 1 ) {
 
 		// Remove <!--fwp-loop--> from output
-		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) {
-			return false;
-		}, 10, 2 );
+		// phpcs:ignore
+		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) { return false; }, 10, 2 );
 
 		// Validate Data
 		$valid_format = array( 'simple', 'complex', 'sexuality', 'gender', 'romantic', 'cliches' );
@@ -272,18 +285,34 @@ class LWTV_Stats_JSON {
 						$died   = ( ! is_array( $died ) ) ? array( $died ) : $died;
 						$shows  = count( get_post_meta( $post->ID, 'lezchars_show_group', true ) );
 						$actors = count( get_post_meta( $post->ID, 'lezchars_actor', true ) );
+						$gender = implode(
+							', ',
+							wp_get_post_terms(
+								$post->ID,
+								'lez_gender',
+								array(
+									'fields' => 'names',
+								)
+							)
+						);
+						$sexual = implode(
+							', ',
+							wp_get_post_terms(
+								$post->ID,
+								'lez_sexuality',
+								array(
+									'fields' => 'names',
+								)
+							)
+						);
 
 						$stats_array[ get_the_title() ] = array(
 							'id'        => $post->ID,
 							'died'      => $died,
 							'actors'    => $actors,
 							'shows'     => $shows,
-							'gender'    => implode(', ', wp_get_post_terms( $post->ID, 'lez_gender', array(
-								'fields' => 'names',
-							) ) ),
-							'sexuality' => implode(', ', wp_get_post_terms( $post->ID, 'lez_sexuality', array(
-								'fields' => 'names',
-							) ) ),
+							'gender'    => $gender,
+							'sexuality' => $sexual,
 							'url'       => get_the_permalink(),
 						);
 					}
@@ -316,9 +345,8 @@ class LWTV_Stats_JSON {
 	 */
 	public static function get_death( $format = 'simple' ) {
 		// Remove <!--fwp-loop--> from output
-		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) {
-			return false;
-		}, 10, 2 );
+		// phpcs:ignore
+		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) { return false; }, 10, 2 );
 
 		// Validate Data
 		$valid_format = array( 'simple', 'complex', 'years' );
@@ -331,7 +359,7 @@ class LWTV_Stats_JSON {
 					'shows'     => LWTV_Stats::generate( 'characters', 'dead-shows', 'array' ),
 					'sexuality' => LWTV_Stats::generate( 'characters', 'dead-sex', 'array' ),
 					'gender'    => LWTV_Stats::generate( 'characters', 'dead-gender', 'array' ),
-					// Current broken :(
+					// Currently broken.
 					//'roles'     => LWTV_Stats::generate( 'characters', 'dead-roles', 'array' ),
 				);
 				break;
@@ -370,9 +398,8 @@ class LWTV_Stats_JSON {
 		global $wpdb;
 
 		// Remove <!--fwp-loop--> from output
-		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) {
-			return false;
-		}, 10, 2 );
+		// phpcs:ignore
+		add_filter( 'facetwp_is_main_query', function( $is_main_query, $query ) { return false; }, 10, 2 );
 
 		// Validate Data
 		$valid_format = array( 'simple', 'complex', 'nations', 'formats', 'stars', 'triggers', 'loved', 'worth-it', 'tropes', 'genres', 'id' );
@@ -501,7 +528,7 @@ class LWTV_Stats_JSON {
 			case 'show':
 				$stats_array = array(
 					'id'              => $id,
-					'title'            => get_the_title( $id ),
+					'title'           => get_the_title( $id ),
 					'nations'         => implode( ', ', wp_get_post_terms( $id, 'lez_country', array( 'fields' => 'names' ) ) ),
 					'stations'        => implode( ', ', wp_get_post_terms( $id, 'lez_stations', array( 'fields' => 'names' ) ) ),
 
@@ -549,22 +576,27 @@ class LWTV_Stats_JSON {
 				$taxonomy = get_terms( array( 'taxonomy' => 'lez_' . $type ) );
 				break;
 			case 'complex':
-				$offset = ( $page - 1 ) * 20;
-				$taxonomy = get_terms( array(
-					'taxonomy' => 'lez_' . $type,
-					'number'   => 20,
-					'offset' => $offset,
-				) );
+				$offset   = ( $page - 1 ) * 20;
+				$taxonomy = get_terms(
+					array(
+						'taxonomy' => 'lez_' . $type,
+						'number'   => 20,
+						'offset'   => $offset,
+					)
+				);
 				break;
 		}
 
 		// Build out the default arrays for character data:
 		foreach ( $valid_subtaxes as $subtax ) {
-			$terms = get_terms( 'lez_' . $subtax, array(
-				'orderby'    => 'count',
-				'order'      => 'DESC',
-				'hide_empty' => 0,
-			) );
+			$terms = get_terms(
+				'lez_' . $subtax,
+				array(
+					'orderby'    => 'count',
+					'order'      => 'DESC',
+					'hide_empty' => 0,
+				)
+			);
 			if ( ! empty( $terms ) && ! is_wp_error( $terms ) ) {
 				foreach ( $terms as $term ) {
 					$char_data[ $term->slug ] = 0;

--- a/rest-api/what-happened.php
+++ b/rest-api/what-happened.php
@@ -36,22 +36,38 @@ class LWTV_What_Happened_JSON {
 	 *   - /lwtv/v1/what-happened/YYYY
 	 */
 	public function rest_api_init() {
-		register_rest_route( 'lwtv/v1', '/what-happened/', array(
-			'methods'  => 'GET',
-			'callback' => array( $this, 'what_happened_rest_api_callback' ),
-		) );
-		register_rest_route( 'lwtv/v1', '/what-happened/(?P<date>[\d]{4}-[\d]{2}-[\d]{2})', array(
-			'methods'  => 'GET',
-			'callback' => array( $this, 'what_happened_rest_api_callback' ),
-		) );
-		register_rest_route( 'lwtv/v1', '/what-happened/(?P<date>[\d]{4}-[\d]{2})', array(
-			'methods'  => 'GET',
-			'callback' => array( $this, 'what_happened_rest_api_callback' ),
-		) );
-		register_rest_route( 'lwtv/v1', '/what-happened/(?P<date>[\d]{4})', array(
-			'methods'  => 'GET',
-			'callback' => array( $this, 'what_happened_rest_api_callback' ),
-		) );
+		register_rest_route(
+			'lwtv/v1',
+			'/what-happened/',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'what_happened_rest_api_callback' ),
+			)
+		);
+		register_rest_route(
+			'lwtv/v1',
+			'/what-happened/(?P<date>[\d]{4}-[\d]{2}-[\d]{2})',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'what_happened_rest_api_callback' ),
+			)
+		);
+		register_rest_route(
+			'lwtv/v1',
+			'/what-happened/(?P<date>[\d]{4}-[\d]{2})',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'what_happened_rest_api_callback' ),
+			)
+		);
+		register_rest_route(
+			'lwtv/v1',
+			'/what-happened/(?P<date>[\d]{4})',
+			array(
+				'methods'  => 'GET',
+				'callback' => array( $this, 'what_happened_rest_api_callback' ),
+			)
+		);
 
 	}
 

--- a/this-year/_main.php
+++ b/this-year/_main.php
@@ -81,7 +81,7 @@ class LWTV_This_Year {
 					<div class="card text-center">
 						<h3 class="card-header alert-success">Characters on Air</h3>
 						<div class="card-body bg-light">
-							<h5 class="card-title" data-toggle="tooltip" data-placement="top" title="Note: This data is curently incomplete and not fully representative of all characters on air at this time. We are working to improve this daily and are current accurate through 2000."><?php echo (int) $array['characters']; ?> <span class="text-danger">*</a></h5>
+							<h5 class="card-title"><?php echo (int) $array['characters']; ?></h5>
 						</div>
 					</div>
 				</div>

--- a/this-year/characters.php
+++ b/this-year/characters.php
@@ -113,8 +113,6 @@ class LWTV_This_Year_Chars {
 
 		<p>&nbsp;</p>
 
-		<div class="alert alert-warning" role="alert"><strong>Notice:</strong> The data generated here is currently curently incomplete and not fully representative of all characters on air at this time. We are working to improve accuracy and are currently accurate through 2000.</div>
-
 		<?php
 		// If the data isn't empty, we go!
 		if ( ! empty( $char_array ) && ! empty( $show_array ) ) {


### PR DESCRIPTION
Teaching Alexa how to find a show you might like if you like a specific show. 

Example:

* "Hey Alexa, ask LezWatch.TV what shows I'd like [besides|other than] SHOWNAME"
* "Hey Alexa, tell LezWatch.TV I like SHOWNAME"

To do this, we've built out a new API called "Shows Like This" which utilizes the API of "related-posts-by-taxonomy"

1. Activate related-posts-by-tax API
2. Tweak details used to find related posts (bump up nations, bump down tropes)
3. Customize related-posts-by-tax to only make the show edits for shows

Additionally:

* PHPCS Compatibility for all of the REST API code
* PHPCS Compat for all Alexa Code
* Disable Slack API because we need to figure out a better way to not call this ALL the time
* Correct year counts
* Improve debug code to look for characters not assigned to a show (or who don't have 'years' on air)
* Improve privacy - if an actor is private, we return NOT queer every single time, no matter what
* Teach affiliates about RoosterTeeth

To Do:

Actually build the Alexa side. There's a lot of work there to make the shows something it can understand, by hooking into IMDB etc.