### PR TITLE
Development: Calendar

### DIFF
--- a/gutenberg/src/calendar.php
+++ b/gutenberg/src/calendar.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Name: Calendar
+ * Description: Code to display the calendar
+ * Version: 1.0
+ */
+
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+class LWTV_SSR_Calendar {
+
+	/**
+	 * Start Date/Time
+	 *
+	 * This will set up the start of the week. It's always Sunday.
+	 *
+	 * @param  string $date The date
+	 * @return object       DateTime object
+	 */
+	public function start_datetime( $date ) {
+		$start_datetime = new DateTime( $date, $tz );
+
+		// If it's not Sunday, we want the previous Sunday
+		if ( 'Sun' !== $start_datetime->format( 'D' ) ) {
+			$start_datetime->modify( 'last Sunday' );
+		}
+
+		return $start_datetime;
+	}
+
+	/**
+	 * End Date/Time
+	 *
+	 * This will set up the End of the week. It's always Saturday.
+	 *
+	 * @param  string $date The date
+	 * @return object       DateTime object
+	 */
+	public function end_datetime( $date ) {
+		$end_datetime = new DateTime( $date, $tz );
+
+		// If it's not Saturday, we want to jump to the next one
+		if ( 'Sat' !== $end_datetime->format( 'D' ) ) {
+			$end_datetime->modify( 'next Saturday' );
+		}
+
+		return $end_datetime;
+	}
+
+	/**
+	 * Previous Date/Time
+	 *
+	 * This will set up the start of the PREVIOUS week. It's always Sunday.
+	 *
+	 * @param  string $date The date
+	 * @return object       DateTime object
+	 */
+	public function prev_datetime( $date ) {
+		$prev_datetime = new DateTime( $date, $tz );
+
+		// If it's not Sunday, we want the previous Sunday
+		if ( 'Sun' !== $prev_datetime->format( 'D' ) ) {
+			$prev_datetime->modify( 'last Sunday' );
+		}
+
+		// Now we need to jump back to the previous week...
+		$prev_datetime->modify( '1 week ago' );
+
+		return $prev_datetime;
+	}
+
+	/**
+	 * Generate correct show name in order to be linked
+	 * @param  string $name Pretty name of show
+	 * @return string       Pretty Name with URL (if exists)
+	 */
+	public function show_name( $name ) {
+
+		switch ( $name ) {
+			case 'Charmed':
+				$name = 'Charmed (2018)';
+				break;
+			case 'Party of Five':
+				$name = 'Party of Five (2020)';
+				break;
+			case 'Shameless':
+				$name = 'Shameless (US)';
+				break;
+			case 'DC\'s Legends of Tomorrow':
+				$name = 'Legends of Tomorrow';
+				break;
+			case 'Marvel\'s Runaways':
+				$name = 'Runaways';
+				break;
+		}
+
+		$show_page_obj = get_page_by_path( sanitize_title( $name ), OBJECT, 'post_type_shows' );
+
+		if ( isset( $show_page_obj->ID ) && 0 !== $show_page_obj->ID ) {
+			$show_name = '<a href="' . get_permalink( $show_page_obj->ID ) . '">' . $name . '</a>';
+		} else {
+			$show_name = $name;
+		}
+
+		return $show_name;
+	}
+
+	/**
+	 * Generate navigation
+	 *
+	 * All dates are 'Y-m-d'
+	 *
+	 * @param  string $date  The date we're building nav for
+	 * @param  string $today Today's date
+	 * @param  string $last  Last week
+	 * @param  string $next  Next week
+	 * @return string       HTML output for the navigation
+	 */
+	public function navigation( $date, $today, $last, $next ) {
+
+		// echo previous and next links:
+		$last_week      = add_query_arg( 'tvdate', $last, get_permalink() );
+		$last_week_icon = LWTV_Functions::symbolicons( 'caret-left-circle.svg', 'fa-chevron-circle-left' );
+		$next_week      = add_query_arg( 'tvdate', $next, get_permalink() );
+		$next_week_icon = LWTV_Functions::symbolicons( 'caret-right-circle.svg', 'fa-chevron-circle-right' );
+
+		$navigation = '<nav aria-label="This Year navigation" role="navigation"><ul class="pagination justify-content-center"><li class="page-item first mr-auto"><a href="' . $last_week . '" class="page-link">' . $last_week_icon . ' Last Week</a></li>';
+
+		// ... We only show 'this week' when it's NOT this week
+		if ( 'today' !== $date && $today !== $date ) {
+			$navigation .= '<li class="page-item active"><a href="/calendar/" class="page-link">This Week</a></li>';
+		}
+
+		$navigation .= '<li class="page-item last ml-auto"><a href="' . $next_week . '" class="page-link">' . $next_week_icon . ' Next Week</a></li></ul></nav>';
+
+		return $navigation;
+	}
+
+}
+
+new LWTV_SSR_Calendar();

--- a/gutenberg/src/serverside-render.php
+++ b/gutenberg/src/serverside-render.php
@@ -47,6 +47,9 @@ class LWTV_ServerSideRendering {
 	 * Render the calendar
 	 */
 	public function render_tvshow_calendar() {
+		// Require the calendar file
+		require_once( 'calendar.php' );
+
 		// Build out start and end dates.
 		$tz    = new DateTimeZone( 'America/New_York' );
 		$today = new DateTime( 'today', $tz );
@@ -54,25 +57,10 @@ class LWTV_ServerSideRendering {
 		// Query Variables.
 		$date_query = ( isset( $_GET['tvdate'] ) && ( $_GET['tvdate'] !== $today->format( 'Y-m-d' ) ) ) ? sanitize_text_field( $_GET['tvdate'] ) : 'today';
 
-		// Calculating the dates three times, which is weird
-		// but every time I try to do it via modify, it
-		// overwrites.
-		if ( 'today' === $date_query ) {
-			$start_datetime = new DateTime( 'today', $tz );
-			$end_datetime   = new DateTime( 'today', $tz );
-			$prev_datetime  = new DateTime( 'today', $tz );
-		} else {
-			$start_datetime = new DateTime( $date_query, $tz );
-			$end_datetime   = new DateTime( $date_query, $tz );
-			$prev_datetime  = new DateTime( $date_query, $tz );
-		}
-
-		// Start on Sunday
-		if ( 'Sun' !== $start_datetime->format( 'D' ) ) {
-			$start_datetime->modify( 'last Sunday' );
-		}
-		$end_datetime->modify( 'next Saturday' );
-		$prev_datetime->modify( '1 week ago' );
+		// Get the dates
+		$start_datetime = LWTV_SSR_Calendar::start_datetime( $date_query );
+		$end_datetime   = LWTV_SSR_Calendar::end_datetime( $date_query );
+		$prev_datetime  = LWTV_SSR_Calendar::prev_datetime( $date_query );
 
 		// Begin the return
 		$return = '<h2 class="lwtv-calendar-week">Week of ' . $start_datetime->format( 'F d, Y' ) . ' - ' . $end_datetime->format( 'F d, Y' ) . ' </h2>';
@@ -80,7 +68,7 @@ class LWTV_ServerSideRendering {
 		// Array
 		$calendar = LWTV_Whats_On_JSON::generate_tvshow_calendar( $start_datetime->format( 'Y-m-d' ) );
 
-		if ( isset( $calendar['none'] ) ) {
+		if ( isset( $calendar['none'] ) || empty( $calendar ) ) {
 			$return .= '<p>There are no shows on the air for this week.</p>';
 		} else {
 			$return .= '<p>All times are displayed as US/Eastern, but are reflective of their original airdate and time.</p>';
@@ -99,33 +87,12 @@ class LWTV_ServerSideRendering {
 
 				foreach ( $shows as $show ) {
 					// Episode Title(s)
-					switch ( $show['show_name'] ) {
-						case 'Charmed':
-							$show['show_name'] = 'Charmed (2018)';
-							break;
-						case 'Party of Five':
-							$show['show_name'] = 'Party of Five (2020)';
-							break;
-						case 'Shameless':
-							$show['show_name'] = 'Shameless (US)';
-							break;
-						case 'DC’s Legends of Tomorrow':
-							$show['show_name'] = 'Legends of Tomorrow';
-							break;
-					}
-
-					$show_page_obj = get_page_by_path( sanitize_title( $show['show_name'] ), OBJECT, 'post_type_shows' );
-
-					if ( isset( $show_page_obj->ID ) && 0 !== $show_page_obj->ID ) {
-						$show_name = '<a href="' . get_permalink( $show_page_obj->ID ) . '">' . $show['show_name'] . '</a>';
-					} else {
-						$show_name = $show['show_name'];
-					}
+					$show_name = LWTV_SSR_Calendar::show_name( $show['show_name'] );
 
 					// Build output
 					$show_content = '<div class="ep-calendar-title">';
 					if ( is_array( $show['title'] ) ) {
-						$show_content .= '<em>' . $show_name . '</em>';
+						$show_content .= '<em>' . $show_name . ' <span class="badge badge-secondary badge-pill">' . count( $show['title'] ) . '</span></em>';
 						$show_content .= '<ul>';
 						foreach ( $show['title'] as $one_show ) {
 							$show_content .= '<li>' . $one_show . '</li>';
@@ -144,31 +111,16 @@ class LWTV_ServerSideRendering {
 				}
 			}
 			$return .= '</tbody></table>';
-
-			// NAVIGATION:
-
-			// NEXT week: Since we set this to Saturday, we have to add a day for the links.
-			$end_datetime->modify( '+1 day' );
-
-			// echo previous and next links:
-			$prev_week = add_query_arg( 'tvdate', $prev_datetime->format( 'Y-m-d' ), get_permalink() );
-			$prev_icon = LWTV_Functions::symbolicons( 'caret-left-circle.svg', 'fa-chevron-circle-left' );
-			$next_week = add_query_arg( 'tvdate', $end_datetime->format( 'Y-m-d' ), get_permalink() );
-			$next_icon = LWTV_Functions::symbolicons( 'caret-right-circle.svg', 'fa-chevron-circle-right' );
-
-			$return .= '<nav aria-label="This Year navigation" role="navigation"><ul class="pagination justify-content-center"><li class="page-item first mr-auto"><a href="' . $prev_week . '" class="page-link">' . $prev_icon . ' Last Week</a></li>';
-
-			// Change today so we can check if the 'this week'
-			// button is needed, because ...
-			$today->modify( 'last Sunday' );
-
-			// ... We only show 'this week' when it's NOT this week
-			if ( 'today' !== $date_query && $today->format( 'Y-m-d' ) !== $date_query ) {
-				$return .= '<li class="page-item active"><a href="/calendar/" class="page-link">This Week</a></li>';
-			}
-
-			$return .= '<li class="page-item last ml-auto"><a href="' . $next_week . '" class="page-link">' . $next_icon . ' Next Week</a></li></ul></nav>';
 		}
+
+		// NAVIGATION
+		// NEXT week: Since we set this to Saturday, we have to add a day for the links.
+		$end_datetime->modify( '+1 day' );
+		// Change today so we can check if the 'this week' button is needed
+		$today->modify( 'last Sunday' );
+
+		$navigation = LWTV_SSR_Calendar::navigation( $date_query, $today->format( 'Y-m-d' ), $prev_datetime->format( 'Y-m-d' ), $end_datetime->format( 'Y-m-d' ) );
+		$return    .= $navigation;
 
 		return $return;
 


### PR DESCRIPTION
* Add another show in to the filter
* Correct the 'end date'
* Only show the 'this week' link if it's not this week
* Minimize redundant calls (speed improvement
* Easier supportability for shows

About the shows names... TV Maze uses a different format for them than we do sometimes, so we need to be able to tweak them. Frankly it would be easier if there weren't reboots and remakes with show names the same, but whatever.