### PR TITLE
Fixing On-Air logic flaw

### DIFF
--- a/cpts/actors/calculations.php
+++ b/cpts/actors/calculations.php
@@ -170,6 +170,9 @@ class LWTV_Actors_Calculate {
 		// Is Queer?
 		$is_queer = ( 'yes' === ( new LWTV_Loops() )->is_actor_queer( $post_id ) ) ? true : false;
 		update_post_meta( $post_id, 'lezactors_queer', $is_queer );
+
+		// Trigger indexing to update facets.
+		FWP()->indexer->index( $post_id );
 	}
 
 }

--- a/cpts/characters/calculations.php
+++ b/cpts/characters/calculations.php
@@ -47,6 +47,9 @@ class LWTV_Characters_Calculate {
 	public function do_the_math( $post_id ) {
 		// Calculate Death
 		self::death( $post_id );
+
+		// Trigger indexing to update facets.
+		FWP()->indexer->index( $post_id );
 	}
 
 }

--- a/cpts/shows/calculations.php
+++ b/cpts/shows/calculations.php
@@ -436,6 +436,17 @@ class LWTV_Shows_Calculate {
 
 		// Update the meta
 		update_post_meta( $post_id, 'lezshows_the_score', $calculate );
+
+		// Cheat and update the show 'on-air' ness.
+		$on_air   = 'no';
+		$airdates = get_post_meta( $post_id, 'lezshows_airdates', true );
+		if ( 'current' === lcfirst( $airdates['finish'] ) || $airdates['finish'] >= gmdate( 'Y' ) ) {
+			$on_air = 'yes';
+		}
+		update_post_meta( $post_id, 'lezshows_on_air', $on_air );
+
+		// Trigger indexing to update facets.
+		FWP()->indexer->index( $post_id );
 	}
 }
 

--- a/plugins/facetwp/lwtv.php
+++ b/plugins/facetwp/lwtv.php
@@ -141,7 +141,10 @@ class LWTV_FacetWP {
 				// Extra check for is it currently on air
 				$params_on_air = $params;
 				$on_air        = 'no';
-				if ( 'current' === lcfirst( $end ) || $end >= gmdate( 'Y' ) ) {
+				$on_air_meta   = get_post_meta( $params['post_id'], 'lezshows_on_air', true );
+				if ( isset( $on_air_meta ) && in_array( $on_air_meta, array( 'yes', 'no' ) ) ) {
+					$on_air = $on_air_meta;
+				} elseif ( 'current' === lcfirst( $end ) || $end > gmdate( 'Y' ) ) {
 					$on_air = 'yes';
 				}
 				$params_on_air['facet_name']          = 'show_on_air';
@@ -172,7 +175,7 @@ class LWTV_FacetWP {
 			}
 
 			// Some extra weird things...
-			// Becuase you can't store data for EMPTY fields so there's a 'fake'
+			// Because you can't store data for EMPTY fields so there's a 'fake'
 			// facet called 'all_the_missing' and we use it to pass through data
 			if ( 'all_the_missing' === $params['facet_name'] ) {
 				// If we do not love the show...

--- a/rest-api/whats-on.php
+++ b/rest-api/whats-on.php
@@ -232,13 +232,15 @@ class LWTV_Whats_On_JSON {
 			// Get the details based on Show ID!
 			$details = self::get_show_details( $show_id, $show_name );
 
-			// Return details:
-			$return = array(
-				'pretty'       => 'The next episode of "' . $show_name . '" ( ' . $details['next'] . ') will air on US/Eastern.',
-				'next'   => $details['next'],
-				'next_summary' => $details['next_summary'],
-				'tvmaze'       => $details['tvmaze'],
-			);
+			if ( is_array( $details ) && isset( $details['next'] ) ) {
+				// Return details:
+				$return = array(
+					'pretty'       => 'The next episode of "' . $show_name . '" ( ' . $details['next'] . ') will air on US/Eastern.',
+					'next'         => $details['next'],
+					'next_summary' => $details['next_summary'],
+					'tvmaze'       => $details['tvmaze'],
+				);
+			}
 		}
 
 		return $return;


### PR DESCRIPTION
If a show is pre-set to be off-air then it may show as 'on air' on the 
shows listing when it's not. 

To fix, I've added in a new meta value for 'On Air' that gets updated 
when the show score is updated (which happens on any un-cached pageload 
or admin-visit). If that's been set, then the facet checker uses that.

Also the calucator now updates the facets, which will pick up all 
changes to the scores etc.

Snuck in a failsafe for canceled shows and whats-on-next.