### PR TITLE
Development

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Do a git checkout including submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -24,7 +24,7 @@ jobs:
         uses: easingthemes/ssh-deploy@main
         env:
           SSH_PRIVATE_KEY: ${{ secrets.LWTV_SSH_KEY }}
-          ARGS: "-rlgoDzvc -i"
+          ARGS: "-rgoDzvc -i"
           REMOTE_HOST: ${{ secrets.LWTV_HOST }}
           REMOTE_USER: ${{ secrets.LWTV_USER }}
           TARGET: /home/${{ secrets.LWTV_USER }}/${{ secrets.LWTV_DEV_DOMAIN }}/wp-content/plugins/lwtv-plugin

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Do a git checkout including submodules
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: true
 
@@ -24,7 +24,7 @@ jobs:
         uses: easingthemes/ssh-deploy@main
         env:
           SSH_PRIVATE_KEY: ${{ secrets.LWTV_SSH_KEY }}
-          ARGS: "-rlgoDzvc -i"
+          ARGS: "-rgoDzvc -i"
           REMOTE_HOST: ${{ secrets.LWTV_HOST }}
           REMOTE_USER: ${{ secrets.LWTV_USER }}
           TARGET: /home/${{ secrets.LWTV_USER }}/${{ secrets.LWTV_DOMAIN }}/wp-content/plugins/lwtv-plugin

--- a/assets/symbolicons.php
+++ b/assets/symbolicons.php
@@ -70,11 +70,14 @@ class LWTV_SymboliconsSettings {
 	 * @return SVG icon of awesomeness
 	 */
 	public function shortcode( $atts ) {
-		$svg = shortcode_atts( array(
-			'file'  => '',
-			'title' => '',
-			'url'   => '',
-		), $atts );
+		$svg = shortcode_atts(
+			array(
+				'file'  => '',
+				'title' => '',
+				'url'   => '',
+			),
+			$atts
+		);
 
 		// Default to the square if nothing is there
 		if ( ! file_exists( LWTV_SYMBOLICONS_PATH . $svg['file'] . '.svg' ) ) {

--- a/cpts/actors/_main.php
+++ b/cpts/actors/_main.php
@@ -211,19 +211,6 @@ class LWTV_CPT_Actors {
 		// unhook this function so it doesn't loop infinitely
 		remove_action( 'save_post_post_type_actors', array( $this, 'save_post_meta' ) );
 
-		// Build Actor Transient
-		$transient = get_transient( 'lwtv_list_actors' );
-		if ( false === $transient || ! in_array( $post_id, $transient ) ) {
-			$transient = ( new LWTV_CMB2() )->get_post_options(
-				array(
-					'post_type'   => 'post_type_actors',
-					'numberposts' => ( 50 + wp_count_posts( 'post_type_actors' )->publish ),
-					'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
-				)
-			);
-			set_transient( 'lwtv_list_actors', $transient, 24 * HOUR_IN_SECONDS );
-		}
-
 		// Do the math
 		( new LWTV_Actors_Calculate() )->do_the_math( $post_id );
 

--- a/cpts/actors/_main.php
+++ b/cpts/actors/_main.php
@@ -200,8 +200,11 @@ class LWTV_CPT_Actors {
 	 */
 	public function save_post_meta( $post_id ) {
 
+		$post_status = get_post_status( $post_id );
+		$post_array  = array( 'publish', 'private' );
+
 		// Prevent running on autosave.
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE || ( 'auto-draft' === get_post_status( $post_id ) ) ) {
+		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! in_array( $post_status, $post_array ) ) {
 			return;
 		}
 

--- a/cpts/actors/calculations.php
+++ b/cpts/actors/calculations.php
@@ -170,9 +170,6 @@ class LWTV_Actors_Calculate {
 		// Is Queer?
 		$is_queer = ( 'yes' === ( new LWTV_Loops() )->is_actor_queer( $post_id ) ) ? true : false;
 		update_post_meta( $post_id, 'lezactors_queer', $is_queer );
-
-		// Trigger indexing to update facets.
-		// FWP()->indexer->index( $post_id );
 	}
 
 }

--- a/cpts/actors/calculations.php
+++ b/cpts/actors/calculations.php
@@ -172,7 +172,7 @@ class LWTV_Actors_Calculate {
 		update_post_meta( $post_id, 'lezactors_queer', $is_queer );
 
 		// Trigger indexing to update facets.
-		FWP()->indexer->index( $post_id );
+		// FWP()->indexer->index( $post_id );
 	}
 
 }

--- a/cpts/characters/_main.php
+++ b/cpts/characters/_main.php
@@ -532,8 +532,11 @@ class LWTV_CPT_Characters {
 	 */
 	public function save_post_meta( $post_id ) {
 
+		$post_status = get_post_status( $post_id );
+		$post_array  = array( 'publish', 'private' );
+
 		// Prevent running on autosave.
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE || ( 'auto-draft' === get_post_status( $post_id ) ) ) {
+		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! in_array( $post_status, $post_array ) ) {
 			return;
 		}
 

--- a/cpts/characters/calculations.php
+++ b/cpts/characters/calculations.php
@@ -53,7 +53,9 @@ class LWTV_Characters_Calculate {
 		$shows = get_post_meta( $post_id, 'lezchars_show_group', true );
 		if ( ! empty( $shows ) ) {
 			foreach ( $shows as $show_id ) {
-				( new LWTV_Shows_Calculate() )->do_the_math( $show_id );
+				if ( isset( $show_id['show'] ) ) {
+					( new LWTV_Shows_Calculate() )->do_the_math( $show_id['show'] );
+				}
 			}
 		}
 	}

--- a/cpts/characters/calculations.php
+++ b/cpts/characters/calculations.php
@@ -94,9 +94,6 @@ class LWTV_Characters_Calculate {
 
 		// Update Actors
 		self::actors( $post_id );
-
-		// Trigger indexing to update facets.
-		// FWP()->indexer->index( $post_id );
 	}
 
 }

--- a/cpts/characters/calculations.php
+++ b/cpts/characters/calculations.php
@@ -96,7 +96,7 @@ class LWTV_Characters_Calculate {
 		self::actors( $post_id );
 
 		// Trigger indexing to update facets.
-		FWP()->indexer->index( $post_id );
+		// FWP()->indexer->index( $post_id );
 	}
 
 }

--- a/cpts/characters/cmb2-metaboxes.php
+++ b/cpts/characters/cmb2-metaboxes.php
@@ -37,14 +37,14 @@ class LWTV_Characters_CMB2 {
 	 * Create a list of all shows
 	 */
 	public function cmb2_get_shows_options() {
-		$count  = ( false === get_transient( 'lwtv_list_shows' ) || ! is_int( get_transient( 'lwtv_list_shows' ) ) ) ? 5000 : get_transient( 'lwtv_list_shows' );
-		$return = ( new LWTV_CMB2() )->get_post_options(
-			array(
-				'post_type'   => 'post_type_shows',
-				'numberposts' => -1,
-			)
-		);
+		$count_shows = get_transient( 'lwtv_count_shows' );
+		$count        = ( false === $count_shows || ! is_int( $count_shows ) ) ? '-1' : $count_shows + 50;
+		$return       = ( new LWTV_CMB2() )->get_post_options( 'post_type_shows', $count );
 
+		$list_shows = get_transient( 'lwtv_list_shows' );
+		if ( ( false === $list_shows ) || ! is_array( $list_shows ) ) {
+			set_transient( 'lwtv_list_actors', $return, 24 * HOUR_IN_SECONDS );
+		}
 		return $return;
 	}
 
@@ -52,13 +52,14 @@ class LWTV_Characters_CMB2 {
 	 * Create a list of all actors
 	 */
 	public function cmb2_get_actors_options() {
-		$count  = ( false === get_transient( 'lwtv_list_actors' ) || ! is_int( get_transient( 'lwtv_list_actors' ) ) ) ? 6000 : get_transient( 'lwtv_list_actors' );
-		$return = ( new LWTV_CMB2() )->get_post_options(
-			array(
-				'post_type'   => 'post_type_actors',
-				'numberposts' => -1,
-			)
-		);
+		$count_actors = get_transient( 'lwtv_count_actors' );
+		$count        = ( false === $count_actors || ! is_int( $count_actors ) ) ? '-1' : $count_actors + 50;
+		$return       = ( new LWTV_CMB2() )->get_post_options( 'post_type_actors', $count );
+
+		$list_actors = get_transient( 'lwtv_list_actors' );
+		if ( ( false === $list_actors ) || ! is_array( $list_actors ) ) {
+			set_transient( 'lwtv_list_actors', $return, 24 * HOUR_IN_SECONDS );
+		}
 
 		return $return;
 	}

--- a/cpts/characters/cmb2-metaboxes.php
+++ b/cpts/characters/cmb2-metaboxes.php
@@ -37,19 +37,15 @@ class LWTV_Characters_CMB2 {
 	 * Create a list of all shows
 	 */
 	public function cmb2_get_shows_options() {
-		// Set transient because this is getting large.
-		$transient = get_transient( 'lwtv_list_shows' );
-		if ( false === $transient ) {
-			$transient = ( new LWTV_CMB2() )->get_post_options(
-				array(
-					'post_type'   => 'post_type_shows',
-					'numberposts' => ( 50 + wp_count_posts( 'post_type_shows' )->publish ),
-					'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
-				)
-			);
-			set_transient( 'lwtv_list_shows', $transient, 24 * HOUR_IN_SECONDS );
-		}
-		$return = $transient;
+		$count  = ( false === get_transient( 'lwtv_list_shows' ) && ! is_int( get_transient( 'lwtv_list_shows' ) ) ) ? 5000 : get_transient( 'lwtv_list_shows' );
+		$return = ( new LWTV_CMB2() )->get_post_options(
+			array(
+				'post_type'   => 'post_type_shows',
+				'numberposts' => 50 + $count,
+				'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
+			)
+		);
+
 		return $return;
 	}
 
@@ -57,19 +53,15 @@ class LWTV_Characters_CMB2 {
 	 * Create a list of all actors
 	 */
 	public function cmb2_get_actors_options() {
-		// Set transient because this is very large.
-		$transient = get_transient( 'lwtv_list_actors' );
-		if ( false === $transient ) {
-			$transient = ( new LWTV_CMB2() )->get_post_options(
-				array(
-					'post_type'   => 'post_type_actors',
-					'numberposts' => ( 50 + wp_count_posts( 'post_type_actors' )->publish ),
-					'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
-				)
-			);
-			set_transient( 'lwtv_list_actors', $transient, 24 * HOUR_IN_SECONDS );
-		}
-		$return = $transient;
+		$count  = ( false === get_transient( 'lwtv_list_actors' ) && ! is_int( get_transient( 'lwtv_list_actors' ) ) ) ? 5000 : get_transient( 'lwtv_list_actors' );
+		$return = ( new LWTV_CMB2() )->get_post_options(
+			array(
+				'post_type'   => 'post_type_actors',
+				'numberposts' => 50 + $count,
+				'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
+			)
+		);
+
 		return $return;
 	}
 

--- a/cpts/characters/cmb2-metaboxes.php
+++ b/cpts/characters/cmb2-metaboxes.php
@@ -37,12 +37,11 @@ class LWTV_Characters_CMB2 {
 	 * Create a list of all shows
 	 */
 	public function cmb2_get_shows_options() {
-		$count  = ( false === get_transient( 'lwtv_list_shows' ) && ! is_int( get_transient( 'lwtv_list_shows' ) ) ) ? 5000 : get_transient( 'lwtv_list_shows' );
+		$count  = ( false === get_transient( 'lwtv_list_shows' ) || ! is_int( get_transient( 'lwtv_list_shows' ) ) ) ? 5000 : get_transient( 'lwtv_list_shows' );
 		$return = ( new LWTV_CMB2() )->get_post_options(
 			array(
 				'post_type'   => 'post_type_shows',
-				'numberposts' => 50 + $count,
-				'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
+				'numberposts' => -1,
 			)
 		);
 
@@ -53,12 +52,11 @@ class LWTV_Characters_CMB2 {
 	 * Create a list of all actors
 	 */
 	public function cmb2_get_actors_options() {
-		$count  = ( false === get_transient( 'lwtv_list_actors' ) && ! is_int( get_transient( 'lwtv_list_actors' ) ) ) ? 5000 : get_transient( 'lwtv_list_actors' );
+		$count  = ( false === get_transient( 'lwtv_list_actors' ) || ! is_int( get_transient( 'lwtv_list_actors' ) ) ) ? 6000 : get_transient( 'lwtv_list_actors' );
 		$return = ( new LWTV_CMB2() )->get_post_options(
 			array(
 				'post_type'   => 'post_type_actors',
-				'numberposts' => 50 + $count,
-				'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
+				'numberposts' => -1,
 			)
 		);
 

--- a/cpts/shows/_main.php
+++ b/cpts/shows/_main.php
@@ -255,8 +255,11 @@ class LWTV_CPT_Shows {
 	 */
 	public function save_post_meta( $post_id, $post, $update ) {
 
+		$post_status = get_post_status( $post_id );
+		$post_array  = array( 'publish', 'private' );
+
 		// Prevent running on autosave.
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE || ( 'auto-draft' === get_post_status( $post_id ) ) ) {
+		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! in_array( $post_status, $post_array ) ) {
 			return;
 		}
 

--- a/cpts/shows/_main.php
+++ b/cpts/shows/_main.php
@@ -269,19 +269,6 @@ class LWTV_CPT_Shows {
 		// Save show scores
 		( new LWTV_Shows_Calculate() )->do_the_math( $post_id );
 
-		// Build Show Transient
-		$transient = get_transient( 'lwtv_list_shows' );
-		if ( false === $transient || ! in_array( $post_id, $transient ) ) {
-			$transient = ( new LWTV_CMB2() )->get_post_options(
-				array(
-					'post_type'   => 'post_type_shows',
-					'numberposts' => ( 50 + wp_count_posts( 'post_type_shows' )->publish ),
-					'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
-				)
-			);
-			set_transient( 'lwtv_list_shows', $transient, 24 * HOUR_IN_SECONDS );
-		}
-
 		// ALWAYS sync up data.
 		foreach ( self::$select2_taxonomies as $postmeta => $taxonomy ) {
 			( new LWTV_CMB2_Addons() )->select2_taxonomy_save( $post_id, $postmeta, $taxonomy );

--- a/cpts/shows/calculations.php
+++ b/cpts/shows/calculations.php
@@ -446,7 +446,7 @@ class LWTV_Shows_Calculate {
 		update_post_meta( $post_id, 'lezshows_on_air', $on_air );
 
 		// Trigger indexing to update facets.
-		FWP()->indexer->index( $post_id );
+		// FWP()->indexer->index( $post_id );
 	}
 }
 

--- a/cpts/shows/calculations.php
+++ b/cpts/shows/calculations.php
@@ -444,9 +444,6 @@ class LWTV_Shows_Calculate {
 			$on_air = 'yes';
 		}
 		update_post_meta( $post_id, 'lezshows_on_air', $on_air );
-
-		// Trigger indexing to update facets.
-		// FWP()->indexer->index( $post_id );
 	}
 }
 

--- a/cpts/shows/cmb2-metaboxes.php
+++ b/cpts/shows/cmb2-metaboxes.php
@@ -68,16 +68,10 @@ class LWTV_Shows_CMB2 {
 	 */
 	public function cmb2_get_shows_options() {
 		$the_id    = ( false !== get_the_ID() ) ? get_the_ID() : 0;
-		$transient = get_transient( 'lwtv_list_shows' );
-		if ( false === $transient ) {
-			$transient = ( new LWTV_CMB2() )->get_post_options(
-				array(
-					'post_type'   => 'post_type_shows',
-					'numberposts' => ( 50 + wp_count_posts( 'post_type_shows' )->publish ),
-					'post_status' => array( 'publish', 'pending', 'draft', 'future' ),
-				)
-			);
-			set_transient( 'lwtv_list_shows', $transient, 24 * HOUR_IN_SECONDS );
+		$transient = get_transient( 'lwtv_count_shows' );
+		if ( false === $transient || ! is_array( $transient ) ) {
+			$transient = ( new LWTV_CMB2() )->get_post_options( 'post_type_shows', '-1' );
+			set_transient( 'lwtv_count_shows', $transient, 24 * HOUR_IN_SECONDS );
 		}
 
 		// Remove THIS show because we use it for related posts

--- a/features/cron.php
+++ b/features/cron.php
@@ -184,25 +184,13 @@ SQL;
 	public function lists_daily() {
 		$list_shows = get_transient( 'lwtv_list_shows' );
 		if ( false === $list_shows ) {
-			$list_shows = ( new LWTV_CMB2() )->get_post_options(
-				array(
-					'post_type'   => 'post_type_shows',
-					'numberposts' => ( 50 + wp_count_posts( 'post_type_shows' )->publish ),
-					'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
-				)
-			);
+			$list_shows =  50 + wp_count_posts( 'post_type_shows' )->publish;
 			set_transient( 'lwtv_list_shows', $list_shows, 24 * HOUR_IN_SECONDS );
 		}
 
 		$list_actors = get_transient( 'lwtv_list_actors' );
 		if ( false === $list_actors ) {
-			$list_actors = ( new LWTV_CMB2() )->get_post_options(
-				array(
-					'post_type'   => 'post_type_actors',
-					'numberposts' => ( 50 + wp_count_posts( 'post_type_actors' )->publish ),
-					'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
-				)
-			);
+			$list_actors = 50 + wp_count_posts( 'post_type_actors' )->publish;
 			set_transient( 'lwtv_list_actors', $list_actors, 24 * HOUR_IN_SECONDS );
 		}
 	}

--- a/features/cron.php
+++ b/features/cron.php
@@ -182,16 +182,16 @@ SQL;
 	 * @return void
 	 */
 	public function lists_daily() {
-		$list_shows = get_transient( 'lwtv_list_shows' );
-		if ( false === $list_shows ) {
-			$list_shows = 50 + wp_count_posts( 'post_type_shows' )->publish;
-			set_transient( 'lwtv_list_shows', $list_shows, 24 * HOUR_IN_SECONDS );
+		$count_shows = get_transient( 'lwtv_count_shows' );
+		if ( false === $count_shows ) {
+			$count_shows = 50 + wp_count_posts( 'post_type_shows' )->publish;
+			set_transient( 'lwtv_count_shows', $count_shows, 24 * HOUR_IN_SECONDS );
 		}
 
-		$list_actors = get_transient( 'lwtv_list_actors' );
-		if ( false === $list_actors ) {
-			$list_actors = 50 + wp_count_posts( 'post_type_actors' )->publish;
-			set_transient( 'lwtv_list_actors', $list_actors, 24 * HOUR_IN_SECONDS );
+		$count_actors = get_transient( 'lwtv_count_actors' );
+		if ( false === $count_actors ) {
+			$count_actors = 50 + wp_count_posts( 'post_type_actors' )->publish;
+			set_transient( 'lwtv_count_actors', $count_actors, 24 * HOUR_IN_SECONDS );
 		}
 	}
 

--- a/features/cron.php
+++ b/features/cron.php
@@ -184,7 +184,7 @@ SQL;
 	public function lists_daily() {
 		$list_shows = get_transient( 'lwtv_list_shows' );
 		if ( false === $list_shows ) {
-			$list_shows =  50 + wp_count_posts( 'post_type_shows' )->publish;
+			$list_shows = 50 + wp_count_posts( 'post_type_shows' )->publish;
 			set_transient( 'lwtv_list_shows', $list_shows, 24 * HOUR_IN_SECONDS );
 		}
 
@@ -226,7 +226,7 @@ SQL;
 				$check = ( new LWTV_Debug() )->find_actors_problems();
 				break;
 			case 'Tue':
-				// Nothing yet.
+				FWP()->indexer->index(); // Ensure Faceting.
 				break;
 			case 'Wed':
 				$check = ( new LWTV_Debug() )->find_actors_no_chars();

--- a/functions.php
+++ b/functions.php
@@ -215,13 +215,13 @@ class LWTV_Functions {
 		$return = '<i class="fas ' . $fontawesome . ' fa-fw" aria-hidden="true"></i>';
 		$square = get_template_directory_uri( '/images/square.svg' );
 
-		if ( defined( 'LWTV_SYMBOLICONS_PATH' ) && file_exists( LWTV_SYMBOLICONS_PATH . $svg ) ) {
+		if ( ! empty( $svg ) && defined( 'LWTV_SYMBOLICONS_PATH' ) && file_exists( LWTV_SYMBOLICONS_PATH . $svg ) ) {
 			$icon = LWTV_SYMBOLICONS_PATH . $svg;
 		} elseif ( ! wp_style_is( 'fontawesome', 'enqueued' ) ) {
 			$icon = $square;
 		}
 
-		if ( isset( $icon ) && ! LWTV_DEV_SITE ) {
+		if ( isset( $icon ) && ! 'LWTV_DEV_SITE' ) {
 			// @codingStandardsIgnoreStart
 			$return = '<span class="symbolicon" role="img">' . file_get_contents( $icon ) . '</span>';
 			// @codingStandardsIgnoreEnd

--- a/functions.php
+++ b/functions.php
@@ -221,7 +221,7 @@ class LWTV_Functions {
 			$icon = $square;
 		}
 
-		if ( isset( $icon ) && ! 'LWTV_DEV_SITE' ) {
+		if ( isset( $icon ) ) {
 			// @codingStandardsIgnoreStart
 			$return = '<span class="symbolicon" role="img">' . file_get_contents( $icon ) . '</span>';
 			// @codingStandardsIgnoreEnd

--- a/plugins/cmb2/cmb-field-select2/js/script.js
+++ b/plugins/cmb2/cmb-field-select2/js/script.js
@@ -1,0 +1,121 @@
+(function ($) {
+	'use strict';
+
+	$('.pw_select').each(function () {
+		$(this).select2({
+			allowClear: true
+		});
+	});
+
+	$.fn.extend({
+		select2_sortable: function () {
+			var select = $(this);
+			$(select).select2();
+			var ul = $(select).next('.select2-container').first('ul.select2-selection__rendered');
+			ul.sortable({
+				containment: 'parent',
+				items      : 'li:not(.select2-search--inline)',
+				tolerance  : 'pointer',
+				stop       : function () {
+					$($(ul).find('.select2-selection__choice').get().reverse()).each(function () {
+						var id = $(this).data('data').id;
+						var option = select.find('option[value="' + id + '"]')[0];
+						$(select).prepend(option);
+					});
+				}
+			});
+		}
+	});
+
+	$('.pw_multiselect').each(function () {
+		$(this).select2_sortable();
+	});
+
+	// Before a new group row is added, destroy Select2. We'll reinitialise after the row is added
+	$('.cmb-repeatable-group').on('cmb2_add_group_row_start', function (event, instance) {
+		var $table = $(document.getElementById($(instance).data('selector')));
+		var $oldRow = $table.find('.cmb-repeatable-grouping').last();
+
+		$oldRow.find('.pw_select2').each(function () {
+			$(this).select2('destroy');
+		});
+	});
+
+	// When a new group row is added, clear selection and initialise Select2
+	$('.cmb-repeatable-group').on('cmb2_add_row', function (event, newRow) {
+		$(newRow).find('.pw_select').each(function () {
+			$('option:selected', this).removeAttr("selected");
+			$(this).select2({
+				allowClear: true
+			});
+		});
+
+		$(newRow).find('.pw_multiselect').each(function () {
+			$('option:selected', this).removeAttr("selected");
+			$(this).select2_sortable();
+		});
+
+		// Reinitialise the field we previously destroyed
+		$(newRow).prev().find('.pw_select').each(function () {
+			$(this).select2({
+				allowClear: true
+			});
+		});
+
+		// Reinitialise the field we previously destroyed
+		$(newRow).prev().find('.pw_multiselect').each(function () {
+			$(this).select2_sortable();
+		});
+	});
+
+	// Before a group row is shifted, destroy Select2. We'll reinitialise after the row shift
+	$('.cmb-repeatable-group').on('cmb2_shift_rows_start', function (event, instance) {
+		var groupWrap = $(instance).closest('.cmb-repeatable-group');
+		groupWrap.find('.pw_select2').each(function () {
+			$(this).select2('destroy');
+		});
+
+	});
+
+	// When a group row is shifted, reinitialise Select2
+	$('.cmb-repeatable-group').on('cmb2_shift_rows_complete', function (event, instance) {
+		var groupWrap = $(instance).closest('.cmb-repeatable-group');
+		groupWrap.find('.pw_select').each(function () {
+			$(this).select2({
+				allowClear: true
+			});
+		});
+
+		groupWrap.find('.pw_multiselect').each(function () {
+			$(this).select2_sortable();
+		});
+	});
+
+	// Before a new repeatable field row is added, destroy Select2. We'll reinitialise after the row is added
+	$('.cmb-add-row-button').on('click', function (event) {
+		var $table = $(document.getElementById($(event.target).data('selector')));
+		var $oldRow = $table.find('.cmb-row').last();
+
+		$oldRow.find('.pw_select2').each(function () {
+			$(this).select2('destroy');
+		});
+	});
+
+	// When a new repeatable field row is added, clear selection and initialise Select2
+	$('.cmb-repeat-table').on('cmb2_add_row', function (event, newRow) {
+
+		// Reinitialise the field we previously destroyed
+		$(newRow).prev().find('.pw_select').each(function () {
+			$('option:selected', this).removeAttr("selected");
+			$(this).select2({
+				allowClear: true
+			});
+		});
+
+		// Reinitialise the field we previously destroyed
+		$(newRow).prev().find('.pw_multiselect').each(function () {
+			$('option:selected', this).removeAttr("selected");
+			$(this).select2_sortable();
+		});
+	});
+})(jQuery);

--- a/plugins/cmb2/lwtv.php
+++ b/plugins/cmb2/lwtv.php
@@ -56,18 +56,15 @@ class LWTV_CMB2 {
 	/**
 	 * Extra Get post options.
 	 */
-	public function get_post_options( $query_args ) {
+	public function get_post_options( $post_type = 'post', $numberposts = '500' ) {
 
 		// Build arguments, based on data sent.
-		$args = wp_parse_args(
-			$query_args,
-			array(
-				'post_type'     => 'post',
-				'numberposts'   => wp_count_posts( 'post' )->publish,
-				'post_status'   => array( 'publish', 'pending', 'draft', 'future', 'private' ),
-				'fields'        => 'ids',
-				'no_found_rows' => true,
-			)
+		$args = array(
+			'post_type'     => $post_type,
+			'numberposts'   => $numberposts,
+			'post_status'   => array( 'publish', 'pending', 'draft', 'future', 'private' ),
+			'fields'        => 'ids',
+			'no_found_rows' => true,
 		);
 
 		// Get the posts
@@ -79,7 +76,7 @@ class LWTV_CMB2 {
 			foreach ( $posts as $post ) {
 				$post_title = get_the_title( $post );
 				// If we're an actor, we should check for queerness.
-				if ( 'post_type_actors' === $query_args['post_type'] ) {
+				if ( 'post_type_actors' === $post_type ) {
 					if ( get_post_meta( $post, 'lezactors_queer', true ) ) {
 						$post_title .= ' (QUEER IRL)';
 					}

--- a/plugins/cmb2/lwtv.php
+++ b/plugins/cmb2/lwtv.php
@@ -62,9 +62,11 @@ class LWTV_CMB2 {
 		$args = wp_parse_args(
 			$query_args,
 			array(
-				'post_type'   => 'post',
-				'numberposts' => wp_count_posts( 'post' )->publish,
-				'post_status' => array( 'publish', 'pending', 'draft', 'future', 'private' ),
+				'post_type'     => 'post',
+				'numberposts'   => wp_count_posts( 'post' )->publish,
+				'post_status'   => array( 'publish', 'pending', 'draft', 'future', 'private' ),
+				'fields'        => 'ids',
+				'no_found_rows' => true,
 			)
 		);
 
@@ -75,16 +77,16 @@ class LWTV_CMB2 {
 		$post_options = array();
 		if ( $posts ) {
 			foreach ( $posts as $post ) {
-				$post_title = $post->post_title;
+				$post_title = get_the_title( $post );
 				// If we're an actor, we should check for queerness.
 				if ( 'post_type_actors' === $query_args['post_type'] ) {
-					if ( get_post_meta( $post->ID, 'lezactors_queer', true ) ) {
+					if ( get_post_meta( $post, 'lezactors_queer', true ) ) {
 						$post_title .= ' (QUEER IRL)';
 					}
 				}
 
 				// Add extra based on status.
-				switch ( get_post_status( $post->ID ) ) {
+				switch ( get_post_status( $post ) ) {
 					case 'draft':
 						$post_title .= ' - DRAFT';
 						break;
@@ -97,7 +99,7 @@ class LWTV_CMB2 {
 						break;
 				}
 
-				$post_options[ $post->ID ] = $post_title;
+				$post_options[ $post ] = $post_title;
 			}
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -191,7 +191,7 @@ The file `_main.php` acts as an autoloader.
     - calls other files
     - generates a CB2 formatted list of terms
 * `/cmb2/` - CMB2 add on libraries
-    - `/cmb-field-select2/` - CMB2 Field Type: Select2
+    - `/cmb-field-select2/` - CMB2 Field Type: Select2 (forked)
     - `/cmb2-grid/` - CMB2 Grid Display
     - `/cmb2.css` - Custom CSS
     - `/lwtv.php` - Special code for us -- Favourite shows for author profiles, Symbolicon support


### PR DESCRIPTION
New Year, new problems

Turns out we hit some limits with query_posts() and number of **actors** which was causing all the issues Carmel saw with them not saving. It was crashing the DB!

For now, the use of transients for listing the actors/shows is disabled, and the use of query_posts() has been changed to _not_ get the posts but instead to get the IDs only. Also, we cache the number of posts per post type to limit the query and streamline that.

I've got a new branch (transients) trying to address that. The problem there is when we add a new actor/show, we have to generate that data so it can be used on character pages. But if generating the data takes too long, it causes actors to fail saving, which means the actor doesn't show up on the character dropdown, which defeats the purpose, doesn't it?