### PR TITLE
New math

### DIFF
--- a/admin/_main.php
+++ b/admin/_main.php
@@ -81,7 +81,7 @@ class LWTV_Admin_Menu {
 	public function admin_enqueue_scripts( $hook ) {
 		// Load only on ?page=mypluginname
 		$my_hooks = array( 'toplevel_page_lwtv', 'lezwatch-tv_page_lwtv_tools' );
-		if ( in_array( $hook, $my_hooks ) ) {
+		if ( in_array( $hook, $my_hooks, true ) ) {
 				wp_enqueue_style( 'lwtv_tools_admin', plugins_url( 'assets/css/lwtv-tools.css', dirname( __FILE__ ) ), array(), '1.0.0' );
 		}
 	}

--- a/admin/admin_tools.php
+++ b/admin/admin_tools.php
@@ -25,7 +25,6 @@ class LWTV_Admin_Tools {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', array( $this, 'add_admin_notices' ) );
-		add_action( 'admin_post_lwtv_tools_fix_actors', array( $this, 'fix_actors_problems' ) );
 		add_action( 'admin_post_lwtv_tools_wikidata_actors', array( $this, 'check_actors_wikidata' ) );
 
 		self::$tool_tabs = array(

--- a/cpts/actors/_main.php
+++ b/cpts/actors/_main.php
@@ -204,7 +204,7 @@ class LWTV_CPT_Actors {
 		$post_array  = array( 'publish', 'private' );
 
 		// Prevent running on autosave.
-		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! in_array( $post_status, $post_array ) ) {
+		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! in_array( $post_status, $post_array, true ) ) {
 			return;
 		}
 

--- a/cpts/actors/calculations.php
+++ b/cpts/actors/calculations.php
@@ -26,7 +26,7 @@ class LWTV_Actors_Calculate {
 		$type_array = array( 'count', 'none', 'dead' );
 
 		// If this isn't an actor post or a valid request, return nothing
-		if ( 'post_type_actors' !== get_post_type( $post_id ) || ! in_array( esc_attr( $type ), $type_array, true ) ) {
+		if ( 'post_type_actors' !== get_post_type( $post_id ) || ! in_array( $type, $type_array, true ) ) {
 			return;
 		}
 
@@ -42,6 +42,7 @@ class LWTV_Actors_Calculate {
 				$characters = wp_list_pluck( $charactersloop->posts, 'ID' );
 			}
 
+			$characters = array_unique( $characters );
 			update_post_meta( $post_id, 'lezactors_char_list', $characters );
 
 			// Reset to end
@@ -51,6 +52,8 @@ class LWTV_Actors_Calculate {
 		// Process character counts:
 		$queercount = 0;
 		$deadcount  = 0;
+
+		$characters = array_unique( $characters );
 
 		foreach ( $characters as $char_id ) {
 			$actors_array = get_post_meta( $char_id, 'lezchars_actor', true );

--- a/cpts/actors/calculations.php
+++ b/cpts/actors/calculations.php
@@ -17,7 +17,7 @@ if ( ! defined( 'WPINC' ) ) {
 class LWTV_Actors_Calculate {
 
 	/*
-	 * Count
+	 * Count all characters for an actor.
 	 *
 	 * @param int $post_id The post ID.
 	 */
@@ -35,18 +35,33 @@ class LWTV_Actors_Calculate {
 
 		// If the character list is empty, we must build it
 		if ( empty( $characters ) ) {
+			$character_checked = array();
+
 			// Loop to get the list of characters
 			$charactersloop = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_actor', $post_id, 'LIKE' );
 
 			if ( $charactersloop->have_posts() ) {
 				$characters = wp_list_pluck( $charactersloop->posts, 'ID' );
 			}
-
-			$characters = array_unique( $characters );
-			update_post_meta( $post_id, 'lezactors_char_list', $characters );
-
 			// Reset to end
 			wp_reset_query();
+
+			$characters = array_unique( $characters );
+
+			foreach ( $characters as $char_id ) {
+				$actors = get_post_meta( $char_id, 'lezchars_actor', true );
+				if ( 'publish' === get_post_status( $char_id ) && isset( $actors ) && ! empty( $actors ) ) {
+					foreach ( $actors as $actor ) {
+						// We have to check because due to so many characters, we have some actor mis-matches.
+						if ( $actor == $the_id ) {  // phpcs:ignore WordPress.PHP.StrictComparisons
+							$character_checked[] = $the_id;
+						}
+					}
+				}
+			}
+
+			update_post_meta( $post_id, 'lezactors_char_list', $character_checked );
+
 		}
 
 		// Process character counts:

--- a/cpts/actors/calculations.php
+++ b/cpts/actors/calculations.php
@@ -30,34 +30,44 @@ class LWTV_Actors_Calculate {
 			return;
 		}
 
-		// Loop to get the list of characters
-		$charactersloop = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_actor', $post_id, 'LIKE' );
-		$queercount     = 0;
-		$deadcount      = 0;
+		// Get array of characters (by ID)
+		$characters = get_post_meta( $post_id, 'lezactors_char_list', true );
 
-		// Store as array to defeat some stupid with counting and prevent querying the database too many times
-		if ( $charactersloop->have_posts() ) {
-			while ( $charactersloop->have_posts() ) {
+		// If the character list is empty, we must build it
+		if ( empty( $characters ) ) {
+			// Loop to get the list of characters
+			$charactersloop = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_actor', $post_id, 'LIKE' );
 
-				$charactersloop->the_post();
-				$char_id      = get_the_ID();
-				$actors_array = get_post_meta( $char_id, 'lezchars_actor', true );
-				$is_dead      = has_term( 'dead', 'lez_cliches', $char_id );
+			if ( $charactersloop->have_posts() ) {
+				$characters = wp_list_pluck( $charactersloop->posts, 'ID' );
+			}
 
-				if ( '' !== $actors_array && 'publish' === get_post_status( $char_id ) ) {
-					foreach ( $actors_array as $char_actor ) {
-						// To compensate for maybe character situations, we need this loose
-						// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-						if ( $char_actor == $post_id ) {
-							$queercount++;
-							if ( $is_dead ) {
-								$deadcount++;
-							}
+			update_post_meta( $post_id, 'lezactors_char_list', $characters );
+
+			// Reset to end
+			wp_reset_query();
+		}
+
+		// Process character counts:
+		$queercount = 0;
+		$deadcount  = 0;
+
+		foreach ( $characters as $char_id ) {
+			$actors_array = get_post_meta( $char_id, 'lezchars_actor', true );
+			$is_dead      = has_term( 'dead', 'lez_cliches', $char_id );
+
+			if ( '' !== $actors_array && 'publish' === get_post_status( $char_id ) ) {
+				foreach ( $actors_array as $char_actor ) {
+					// To compensate for maybe character situations, we need this loose
+					// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+					if ( $char_actor == $post_id ) {
+						$queercount++;
+						if ( $is_dead ) {
+							$deadcount++;
 						}
 					}
 				}
 			}
-			wp_reset_query();
 		}
 
 		// Let us return Queers!
@@ -71,78 +81,6 @@ class LWTV_Actors_Calculate {
 		}
 
 		return $output;
-	}
-
-	/**
-	 * lists
-	 *
-	 * Can generate lists of character or show IDs associated with this actor.
-	 * We save them as IDs so we can live render the display names (just in case
-	 * anything changed and we don't want to re-save)
-	 *
-	 * @param  int    $post_id post ID
-	 * @param  string $type    what type of data we want
-	 * @return array          array of generated IDs
-	 */
-	public function list( $post_id, $type ) {
-		$type_array = array( 'characters', 'shows' );
-
-		// If this isn't an actor post or a valid request, return nothing
-		if ( 'post_type_actors' !== get_post_type( $post_id ) || ! in_array( esc_attr( $type ), $type_array, true ) ) {
-			return;
-		}
-
-		// Empty return for now.
-		$output     = '';
-		$char_array = array();
-		$show_array = array();
-
-		// Get a loop of all the characters that MIGHT belong to this actor, based on actor postID
-		// This will have some falsies, so hang on...
-		$loop = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_actor', $post_id, 'LIKE' );
-		if ( $loop->have_posts() ) {
-			while ( $loop->have_posts() ) {
-				$loop->the_post();
-				$char_id = get_the_ID();
-
-				// Get the array of actors per character
-				$actors_array = get_post_meta( $char_id, 'lezchars_actor', true );
-				if ( '' !== $actors_array && 'publish' === get_post_status( $char_id ) ) {
-					foreach ( $actors_array as $char_actor ) {
-						// To compensate for MAYBE character situations, we need this loose
-						// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-						if ( $char_actor == $post_id ) {
-							// There is a hit for the actor ID based on the character's list
-							// This is a POSITIVE! Save the ID
-							$char_array[] = $char_id;
-
-							// Loop through all shows for the character and save that as $show_array
-							// Save the ID
-							$shows_group = get_post_meta( $char_id, 'lezchars_show_group', true );
-							if ( '' !== $shows_group && is_array( $shows_group ) ) {
-								foreach ( $shows_group as $each_show ) {
-									$show_array[] = $each_show['show'];
-								}
-							}
-						}
-					}
-				}
-			}
-			wp_reset_query();
-		}
-
-		// Let us return data!
-		switch ( $type ) {
-			case 'characters':
-				$output = $char_array;
-				break;
-			case 'shows':
-				$output = $show_array;
-				break;
-		}
-
-		return $output;
-
 	}
 
 	/**
@@ -162,10 +100,6 @@ class LWTV_Actors_Calculate {
 		// Update counts
 		update_post_meta( $post_id, 'lezactors_char_count', self::count( $post_id, 'count' ) );
 		update_post_meta( $post_id, 'lezactors_dead_count', self::count( $post_id, 'dead' ) );
-
-		// Update lists
-		update_post_meta( $post_id, 'lezactors_char_list', self::list( $post_id, 'characters' ) );
-		update_post_meta( $post_id, 'lezactors_show_list', self::list( $post_id, 'shows' ) );
 
 		// Is Queer?
 		$is_queer = ( 'yes' === ( new LWTV_Loops() )->is_actor_queer( $post_id ) ) ? true : false;

--- a/cpts/actors/cmb2-metaboxes.php
+++ b/cpts/actors/cmb2-metaboxes.php
@@ -258,7 +258,7 @@ class LWTV_Actors_CMB2 {
 			array(
 				'name'      => 'Additional Notes',
 				'id'        => 'excerpt',
-				'desc'      => 'Enter any terms here that should be used for search. For example, if someone change their name, list their deadname here so it can be searched.',
+				'desc'      => 'Enter any terms here that should be used for search. For example, if someone changed their name, you would list their deadname here so it can be searched.',
 				'type'      => 'textarea',
 				'escape_cb' => false,
 				'default'   => get_post_field( 'post_excerpt' ),

--- a/cpts/characters/_main.php
+++ b/cpts/characters/_main.php
@@ -520,7 +520,7 @@ class LWTV_CPT_Characters {
 		$post_array  = array( 'publish', 'private' );
 
 		// Prevent running on autosave.
-		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! in_array( $post_status, $post_array ) ) {
+		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! in_array( $post_status, $post_array, true ) ) {
 			return;
 		}
 

--- a/cpts/characters/_main.php
+++ b/cpts/characters/_main.php
@@ -291,9 +291,29 @@ class LWTV_CPT_Characters {
 	 * @return void
 	 */
 	public function list_characters( $show_id, $output = 'query' ) {
-		$charactersloop = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_show_group', $show_id, 'LIKE' );
-		$characters     = array();
-		$char_counts    = array(
+
+		// Get array of characters (by ID)
+		$characters = get_post_meta( $show_id, 'lezshows_char_list', true );
+
+		// If the character list is empty, we must build it
+		if ( empty( $characters ) ) {
+			// Loop to get the list of characters
+			$charactersloop = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_show_group', $show_id, 'LIKE' );
+
+			if ( $charactersloop->have_posts() ) {
+				$characters = wp_list_pluck( $charactersloop->posts, 'ID' );
+			}
+
+			$characters = array_unique( $characters );
+			update_post_meta( $show_id, 'lezshows_char_list', $characters );
+
+			// Reset to end
+			wp_reset_query();
+		}
+
+		$characters = array_unique( $characters );
+
+		$char_counts = array(
 			'total' => 0,
 			'dead'  => 0,
 			'none'  => 0,
@@ -302,88 +322,63 @@ class LWTV_CPT_Characters {
 			'txirl' => 0,
 		);
 
-		// Store as array to defeat some stupid with counting and prevent querying the database too many times
-		if ( $charactersloop->have_posts() ) {
-			while ( $charactersloop->have_posts() ) {
-				$charactersloop->the_post();
-				$char_id     = get_the_ID();
-				$shows_array = get_post_meta( $char_id, 'lezchars_show_group', true );
+		foreach ( $characters as $char_id ) {
+			// Get the list of shows.
+			$shows_array = get_post_meta( $char_id, 'lezchars_show_group', true );
 
-				// If the character is in this show, AND a published character
-				// we will pass the following data to the character template
-				// to determine what to display
-				if (
-					'' !== $shows_array &&
-					! empty( $shows_array ) &&
-					'publish' === get_post_status( $char_id )
-				) {
-					foreach ( $shows_array as $char_show ) {
-						if ( (int) $char_show['show'] === $show_id ) {
-							$characters[ $char_id ] = array(
-								'id'        => $char_id,
-								'title'     => get_the_title( $char_id ),
-								'url'       => get_the_permalink( $char_id ),
-								'content'   => get_the_content( $char_id ),
-								'shows'     => $shows_array,
-								'show_from' => $show_id,
-							);
+			// If the character is in this show, AND a published character
+			// we will pass the following data to the character template
+			// to determine what to display
+			if (
+				'' !== $shows_array &&
+				! empty( $shows_array ) &&
+				'publish' === get_post_status( $char_id )
+			) {
+				foreach ( $shows_array as $char_show ) {
+					if ( (int) $char_show['show'] === $show_id ) {
+						// Get a list of actors (we need this twice later)
+						$actors_ids = get_post_meta( $char_id, 'lezchars_actor', true );
+						if ( ! is_array( $actors_ids ) ) {
+							$actors_ids = array( $actors_ids );
+						}
 
-							// Get a list of actors (we need this twice later)
-							$actors_ids = get_post_meta( $char_id, 'lezchars_actor', true );
-							if ( ! is_array( $actors_ids ) ) {
-								$actors_ids = array( get_post_meta( $char_id, 'lezchars_actor', true ) );
-							}
+						// Increase the count of characters
+						$char_counts['total']++;
 
-							// Increase the count of characters
-							$char_counts['total']++;
+						// Dead?
+						if ( has_term( 'dead', 'lez_cliches', $char_id ) ) {
+							$char_counts['dead']++;
+						}
+						// No cliches?
+						if ( has_term( 'none', 'lez_cliches', $char_id ) ) {
+							$char_counts['none']++;
+						}
+						// The Tambour Takedown: Checking Queer IRL
+						// We don't award shows that have cast a cis/het actor in a queer
+						// role. To solve this, we grab the actor listed as PRIMARY ACTOR
+						// (i.e. the one listed first). If THEY are QIRL, the show gets points.
+						if ( has_term( 'queer-irl', 'lez_cliches', $char_id ) ) {
+							$top_actor = reset( $actors_ids );
+							if ( 'yes' === ( new LWTV_Loops() )->is_actor_queer( $top_actor ) ) {
+								$char_counts['quirl']++;
+							}
+						}
 
-							// Dead?
-							if ( has_term( 'dead', 'lez_cliches', $char_id ) ) {
-								$char_counts['dead']++;
-							}
-							// No cliches?
-							if ( has_term( 'none', 'lez_cliches', $char_id ) ) {
-								$char_counts['none']++;
-							}
-							// The Tambour Takedown: Checking Queer IRL
-							// This is a little more complicated. We don't want to award
-							// points if a show has primarily cast a cis/het actor as a
-							// queer role. To solve this, we grab the actor listed as
-							// PRIMARY (i.e. the one listed first). If THEY are QIRL,
-							// the show gets the points.
-							if ( has_term( 'queer-irl', 'lez_cliches', $char_id ) ) {
-								$top_actor = reset( $actors_ids );
-								if ( 'yes' === ( new LWTV_Loops() )->is_actor_queer( $top_actor ) ) {
-									$char_counts['quirl']++;
-								}
-							}
-							// Is Trans?
-							$valid_trans_char = array( 'trans-man', 'trans-woman' );
-							if ( has_term( $valid_trans_char, 'lez_gender', $char_id ) ) {
-								$char_counts['trans']++;
-							}
+						// Is the character is not Cisgender ...
+						$valid_trans_char = array( 'cisgender', 'intersex', 'unknown' );
+						if ( ! has_term( $valid_trans_char, 'lez_gender', $char_id ) ) {
+							$char_counts['trans']++;
+						}
 
-							// Now to see if we have trans IRL...
-							foreach ( $actors_ids as $actor ) {
-								if ( 'yes' === ( new LWTV_Loops() )->is_actor_trans( $actor ) ) {
-									$char_counts['txirl']++;
-									// It's possible to have MORE trans actors than characters.
-								}
+						// If an actor is transgender, we get an extra bonus.
+						foreach ( $actors_ids as $actor ) {
+							if ( 'yes' === ( new LWTV_Loops() )->is_actor_trans( $actor ) ) {
+								$char_counts['txirl']++;
 							}
-						} else {
-							// If they're not published, or not in the show, we drop
-							// them from the array. This is because show 123 will false
-							// flag 1234 sometimes.
-							unset( $charactersloop->posts[ $char_id ] );
 						}
 					}
-				} else {
-					// If they're not published, or not in the show, we drop them from
-					// the array. This is because show 123 will false flag 1234 sometimes.
-					unset( $charactersloop->posts[ $char_id ] );
 				}
 			}
-			wp_reset_query();
 		}
 
 		switch ( $output ) {
@@ -408,8 +403,8 @@ class LWTV_CPT_Characters {
 				$return = $char_counts['txirl'];
 				break;
 			case 'query':
-				// WP Loop of characters
-				$return = $charactersloop;
+				// WP Array of all characters
+				$return = $characters;
 				break;
 			case 'count':
 				// Count of all characters on the show
@@ -452,8 +447,6 @@ class LWTV_CPT_Characters {
 		 * Calculate the max number of characters to list, based on the
 		 * previous count. Default/Minimum is the number of characters divided by 10
 		 */
-		$precount = wp_count_posts( 'post_type_characters' )->publish;
-		$count    = ( isset( $havecharcount ) && $havecharcount >= intdiv( $precount, 10 ) ) ? $havecharcount : intdiv( $precount, 10 );
 
 		// Valid Roles:
 		$valid_roles = array( 'regular', 'recurring', 'guest' );
@@ -463,64 +456,55 @@ class LWTV_CPT_Characters {
 			return;
 		}
 
-		// Prepare the ARRAY
-		$characters = array();
+		// Get array of characters (by ID)
+		$characters = get_post_meta( $show_id, 'lezshows_char_list', true );
 
-		$charactersloop = new WP_Query(
-			array(
-				'post_type'              => 'post_type_characters',
-				'post_status'            => array( 'publish' ),
-				'orderby'                => 'title',
-				'order'                  => 'ASC',
-				'posts_per_page'         => $count,
-				'no_found_rows'          => true,
-				'update_post_term_cache' => true,
-				'meta_query'             => array(
-					'relation' => 'AND',
-					array(
-						'key'     => 'lezchars_show_group',
-						'value'   => $role,
-						'compare' => 'LIKE',
-					),
-					array(
-						'key'     => 'lezchars_show_group',
-						'value'   => $show_id,
-						'compare' => 'REGEXP',
-					),
-				),
-			)
-		);
+		// If the character list is empty, we must build it
+		if ( empty( $characters ) ) {
+			// Loop to get the list of characters
+			$charactersloop = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_show_group', $show_id, 'LIKE' );
 
-		if ( $charactersloop->have_posts() ) {
-			while ( $charactersloop->have_posts() ) {
-				$charactersloop->the_post();
-				$char_id     = get_the_ID();
-				$shows_array = get_post_meta( $char_id, 'lezchars_show_group', true );
+			if ( $charactersloop->have_posts() ) {
+				$characters = wp_list_pluck( $charactersloop->posts, 'ID' );
+			}
 
-				// If the character is in this show, AND a published character,
-				// AND has this role ON THIS SHOW we will pass the following
-				// data to the character template to determine what to display.
-				if ( 'publish' === get_post_status( $char_id ) && isset( $shows_array ) && ! empty( $shows_array ) ) {
-					foreach ( $shows_array as $char_show ) {
-						// Because of show IDs having SIMILAR numbers, we need to be a little more flex
-						// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
-						if ( $char_show['show'] == $show_id && $char_show['type'] === $role ) {
-							$characters[ $char_id ] = array(
-								'id'        => $char_id,
-								'title'     => get_the_title( $char_id ),
-								'url'       => get_the_permalink( $char_id ),
-								'content'   => get_the_content( $char_id ),
-								'shows'     => $shows_array,
-								'show_from' => $show_id,
-								'role_from' => $role,
-							);
-						}
+			$characters = array_unique( $characters );
+			update_post_meta( $post_id, 'lezshows_char_list', $characters );
+
+			// Reset to end
+			wp_reset_query();
+		}
+
+		// Empty array to display later
+		$display    = array();
+		$characters = array_unique( $characters );
+
+		foreach ( $characters as $char_id ) {
+			$shows_array = get_post_meta( $char_id, 'lezchars_show_group', true );
+
+			// If the character is in this show, AND a published character,
+			// AND has this role ON THIS SHOW we will pass the following
+			// data to the character template to determine what to display.
+			if ( 'publish' === get_post_status( $char_id ) && isset( $shows_array ) && ! empty( $shows_array ) ) {
+				foreach ( $shows_array as $char_show ) {
+					// Because of show IDs having SIMILAR numbers, we need to be a little more flex
+					// phpcs:ignore WordPress.PHP.StrictComparisons.LooseComparison
+					if ( $char_show['show'] == $show_id && $char_show['type'] === $role ) {
+						$display[ $char_id ] = array(
+							'id'        => $char_id,
+							'title'     => get_the_title( $char_id ),
+							'url'       => get_the_permalink( $char_id ),
+							'content'   => get_the_content( $char_id ),
+							'shows'     => $shows_array,
+							'show_from' => $show_id,
+							'role_from' => $role,
+						);
 					}
 				}
 			}
-			wp_reset_query();
 		}
-		return $characters;
+
+		return $display;
 	}
 
 	/*

--- a/cpts/characters/calculations.php
+++ b/cpts/characters/calculations.php
@@ -61,6 +61,7 @@ class LWTV_Characters_Calculate {
 						$characters = array();
 					}
 					$characters[] = $post_id;
+					$characters = array_unique( $characters );
 					update_post_meta( $show_id['show'], 'lezshows_char_list', $characters );
 
 					( new LWTV_Shows_Calculate() )->do_the_math( $show_id['show'] );
@@ -100,7 +101,7 @@ class LWTV_Characters_Calculate {
 					$characters[] = $post_id;
 
 					// Remove Duplicates just in case.
-					array_unique( $characters );
+					$characters = array_unique( $characters );
 
 					// Update List of characters for the actor
 					update_post_meta( $actor_id, 'lezactors_char_list', $characters );

--- a/cpts/characters/calculations.php
+++ b/cpts/characters/calculations.php
@@ -92,20 +92,9 @@ class LWTV_Characters_Calculate {
 					$characters = array();
 				}
 
-				if ( ! is_array( $characters ) ) {
-					$characters = array( $characters );
-				}
-
-				// If the character isn't already in the array, we add it.
-				if ( ! in_array( $post_id, $characters, true ) ) {
-					$characters[] = $post_id;
-
-					// Remove Duplicates just in case.
-					$characters = array_unique( $characters );
-
-					// Update List of characters for the actor
-					update_post_meta( $actor_id, 'lezactors_char_list', $characters );
-				}
+				$characters[] = $post_id;
+				$characters   = array_unique( $characters );
+				update_post_meta( $actor_id, 'lezactors_char_list', $characters );
 
 				( new LWTV_Actors_Calculate() )->do_the_math( $actor_id );
 			}

--- a/cpts/characters/calculations.php
+++ b/cpts/characters/calculations.php
@@ -61,7 +61,7 @@ class LWTV_Characters_Calculate {
 						$characters = array();
 					}
 					$characters[] = $post_id;
-					$characters = array_unique( $characters );
+					$characters   = array_unique( $characters );
 					update_post_meta( $show_id['show'], 'lezshows_char_list', $characters );
 
 					( new LWTV_Shows_Calculate() )->do_the_math( $show_id['show'] );
@@ -97,7 +97,7 @@ class LWTV_Characters_Calculate {
 				}
 
 				// If the character isn't already in the array, we add it.
-				if ( ! in_array( $post_id, $characters ) ) {
+				if ( ! in_array( $post_id, $characters, true ) ) {
 					$characters[] = $post_id;
 
 					// Remove Duplicates just in case.

--- a/cpts/characters/calculations.php
+++ b/cpts/characters/calculations.php
@@ -54,6 +54,15 @@ class LWTV_Characters_Calculate {
 		if ( ! empty( $shows ) ) {
 			foreach ( $shows as $show_id ) {
 				if ( isset( $show_id['show'] ) ) {
+
+					// Add character to list for show
+					$characters = get_post_meta( $show_id['show'], 'lezshows_char_list', true );
+					if ( empty( $characters ) ) {
+						$characters = array();
+					}
+					$characters[] = $post_id;
+					update_post_meta( $show_id['show'], 'lezshows_char_list', $characters );
+
 					( new LWTV_Shows_Calculate() )->do_the_math( $show_id['show'] );
 				}
 			}
@@ -68,13 +77,35 @@ class LWTV_Characters_Calculate {
 	 * @return N/A   No return, just update actor calculation
 	 */
 	public function actors( $post_id ) {
-		// Generate List of Actors
+		// Array of Actors saved to post
 		$actors = get_post_meta( $post_id, 'lezchars_actor', true );
 		if ( ! is_array( $actors ) ) {
-			$actors = array( get_post_meta( $post_id, 'lezchars_actor', true ) );
+			$actors = array( $actors );
 		}
 		if ( ! empty( $actors ) ) {
 			foreach ( $actors as $actor_id ) {
+
+				// Add array of characters by ID to actor as post meta
+				$characters = get_post_meta( $actor_id, 'lezactors_char_list', true );
+				if ( empty( $characters ) ) {
+					$characters = array();
+				}
+
+				if ( ! is_array( $characters ) ) {
+					$characters = array( $characters );
+				}
+
+				// If the character isn't already in the array, we add it.
+				if ( ! in_array( $post_id, $characters ) ) {
+					$characters[] = $post_id;
+
+					// Remove Duplicates just in case.
+					array_unique( $characters );
+
+					// Update List of characters for the actor
+					update_post_meta( $actor_id, 'lezactors_char_list', $characters );
+				}
+
 				( new LWTV_Actors_Calculate() )->do_the_math( $actor_id );
 			}
 		}

--- a/cpts/characters/cmb2-metaboxes.php
+++ b/cpts/characters/cmb2-metaboxes.php
@@ -182,7 +182,7 @@ class LWTV_Characters_CMB2 {
 		// Field: Show Name
 		$field_shows = $cmb_characters->add_group_field(
 			$group_shows,
-			array (
+			array(
 				'name'            => 'TV Show',
 				'id'              => 'show',
 				'desc'            => 'Click on the search icon to select the show.',

--- a/cpts/post-meta.php
+++ b/cpts/post-meta.php
@@ -20,6 +20,7 @@ class LWTV_CPT_Post_Meta {
 
 		self::$all_post_metas = array(
 			// Meta Name                    => Post Type
+			// Actors
 			'lezactors_birth'               => 'post_type_actors',
 			'lezactors_death'               => 'post_type_actors',
 			'lezactors_imdb'                => 'post_type_actors',
@@ -28,9 +29,12 @@ class LWTV_CPT_Post_Meta {
 			'lezactors_twitter'             => 'post_type_actors',
 			'lezactors_tumblr'              => 'post_type_actors',
 			'lezactors_instagram'           => 'post_type_actors',
+			'lezactors_mastodon'            => 'post_type_actors',
+			// Characters
 			'lezchars_death_year'           => 'post_type_characters',
 			'lezchars_actor'                => 'post_type_characters',
 			'lezchars_show_group'           => 'post_type_characters',
+			// Shows
 			'lezshows_airdates'             => 'post_type_shows',
 			'lezshows_seasons'              => 'post_type_shows',
 			'lezshows_tvtype'               => 'post_type_shows',

--- a/cpts/related-posts.php
+++ b/cpts/related-posts.php
@@ -34,10 +34,16 @@ class LWTV_Related_Posts {
 		}
 
 		$related_post_loop  = ( new LWTV_Loops() )->related_posts_by_tag( 'post', $slug );
-		$related_post_query = wp_list_pluck( $related_post_loop->posts, 'ID' );
-		$the_related_posts  = '<em>Coming soon...</em>';
 
 		if ( $related_post_loop->have_posts() ) {
+			$related_post_query = wp_list_pluck( $related_post_loop->posts, 'ID' );
+			$related_post_query = array_unique( $related_post_query );
+			wp_reset_query();
+		}
+
+		$the_related_posts  = '<em>Coming soon...</em>';
+
+		if ( is_array( $related_post_query ) ) {
 
 			// We get a max of 10 but we only want to show 5
 			$max_posts  = 3;
@@ -71,7 +77,7 @@ class LWTV_Related_Posts {
 
 		$related_post_loop  = ( new LWTV_Loops() )->related_posts_by_tag( 'post', $slug );
 		$related_post_query = wp_list_pluck( $related_post_loop->posts, 'ID' );
-
+		$related_post_query = array_unique( $related_post_query );
 		return $related_post_query;
 	}
 

--- a/cpts/related-posts.php
+++ b/cpts/related-posts.php
@@ -33,7 +33,7 @@ class LWTV_Related_Posts {
 			return;
 		}
 
-		$related_post_loop  = ( new LWTV_Loops() )->related_posts_by_tag( 'post', $slug );
+		$related_post_loop = ( new LWTV_Loops() )->related_posts_by_tag( 'post', $slug );
 
 		if ( $related_post_loop->have_posts() ) {
 			$related_post_query = wp_list_pluck( $related_post_loop->posts, 'ID' );
@@ -41,7 +41,7 @@ class LWTV_Related_Posts {
 			wp_reset_query();
 		}
 
-		$the_related_posts  = '<em>Coming soon...</em>';
+		$the_related_posts = '<em>Coming soon...</em>';
 
 		if ( is_array( $related_post_query ) ) {
 

--- a/cpts/shows/_main.php
+++ b/cpts/shows/_main.php
@@ -259,7 +259,7 @@ class LWTV_CPT_Shows {
 		$post_array  = array( 'publish', 'private' );
 
 		// Prevent running on autosave.
-		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! in_array( $post_status, $post_array ) ) {
+		if ( ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || ! in_array( $post_status, $post_array, true ) ) {
 			return;
 		}
 

--- a/cpts/shows/calculations.php
+++ b/cpts/shows/calculations.php
@@ -111,7 +111,7 @@ class LWTV_Shows_Calculate {
 		$type_array = array( 'count', 'none', 'dead', 'queer-irl', 'score' );
 
 		// If this isn't one of the above types, return.
-		if ( ! in_array( esc_attr( $type ), $type_array, true ) ) {
+		if ( ! in_array( $type, $type_array, true ) ) {
 			return;
 		}
 
@@ -360,7 +360,7 @@ class LWTV_Shows_Calculate {
 		}
 
 		// Get array of characters (by ID)
-		$characters = get_post_meta( $post_id, 'lezshows_char_list', true );
+		$characters = array_unique( get_post_meta( $post_id, 'lezshows_char_list', true ) );
 
 		// If the character list is empty, we must build it
 		if ( empty( $characters ) ) {
@@ -371,6 +371,7 @@ class LWTV_Shows_Calculate {
 				$characters = wp_list_pluck( $charactersloop->posts, 'ID' );
 			}
 
+			$characters = array_unique( $characters );
 			update_post_meta( $post_id, 'lezshows_char_list', $characters );
 
 			// Reset to end

--- a/cpts/shows/cmb2-metaboxes.php
+++ b/cpts/shows/cmb2-metaboxes.php
@@ -448,8 +448,6 @@ class LWTV_Shows_CMB2 {
 				'repeatable'       => true,
 			)
 		);
-
-
 		// Field Group: Show Name Information
 		$group_names = $cmb_mustsee->add_field(
 			array(

--- a/cpts/shows/shows-like-this.php
+++ b/cpts/shows/shows-like-this.php
@@ -193,6 +193,8 @@ class LWTV_Shows_Like_This {
 				$results = wp_list_pluck( $results, 'ID' );
 			}
 
+			$results = array_unique( $results );
+
 			// What MIGHT we be adding:
 			$handpicked  = ( get_post_meta( $post_id, 'lezshows_similar_shows', true ) ) ? wp_parse_id_list( get_post_meta( $post_id, 'lezshows_similar_shows', true ) ) : array();
 			$reciprocity = self::reciprocity( $post_id );

--- a/features/custom-roles.php
+++ b/features/custom-roles.php
@@ -108,7 +108,7 @@ class LWTV_Roles {
 		global $current_user, $menu;
 		wp_get_current_user();
 
-		if ( in_array( 'data_editor', $current_user->roles ) ) {
+		if ( in_array( 'data_editor', $current_user->roles, true ) ) {
 			remove_menu_page( 'index.php' );                  //Dashboard
 			remove_menu_page( 'edit.php' );                   //Posts
 			remove_menu_page( 'edit.php?post_type=page' );    //Pages
@@ -133,13 +133,13 @@ class LWTV_Roles {
 		global $pagenow, $current_user;
 		wp_get_current_user();
 
-		if ( in_array( 'data_editor', $current_user->roles ) ) {
+		if ( in_array( 'data_editor', $current_user->roles, true ) ) {
 			$disallowed_pages = array( 'index.php', 'edit-comments.php', 'themes.php', 'tools.php', 'plugins.php', 'options-general.php' );
 			$allowed_cpts     = array( 'post_type_shows', 'post_type_actors', 'post_type_characters' );
 
 			# Check current admin page.
-			if ( in_array( $pagenow, $disallowed_pages ) || ( 'edit.php' === $pagenow && ( null === $_GET['post_type'] || ( isset( $_GET['post_type'] ) && ! in_array( $_GET['post_type'], $allowed_cpts ) ) ) ) ) {
-				wp_redirect( admin_url( '/admin.php?page=lwtv' ) );
+			if ( in_array( $pagenow, $disallowed_pages, true ) || ( 'edit.php' === $pagenow && ( null === $_GET['post_type'] || ( isset( $_GET['post_type'] ) && ! in_array( $_GET['post_type'], $allowed_cpts, true ) ) ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+				wp_safe_redirect( admin_url( '/admin.php?page=lwtv' ) );
 				exit;
 			}
 		}

--- a/features/socials.php
+++ b/features/socials.php
@@ -21,7 +21,7 @@ class LWTV_Social_Media {
 
 	/** Add rel="me" to social menu items. */
 	public function add_rel_me( $items, $args ) {
-		if ( 'follow-us' == $args->menu->name ) {
+		if ( 'follow-us' === $args->menu->name ) {
 			foreach ( $items as $i ) {
 				$i->xfn .= ' me';
 			}

--- a/features/wp-cli.php
+++ b/features/wp-cli.php
@@ -181,13 +181,9 @@ class WP_CLI_LWTV_Commands {
 				$items = ( new LWTV_Debug() )->find_queerchars();
 				break;
 			case 'nochars':
-				if ( $try_to_fix ) {
-					WP_CLI::log( 'Attempting to fix actors without characters ....' );
-					$items = ( new LWTV_Debug() )->fix_actors_no_chars();
-				} else {
-					WP_CLI::log( 'Searching all actors to ensure they have a character ....' );
-					$items = ( new LWTV_Debug() )->find_actors_no_chars();
-				}
+				WP_CLI::log( 'Searching all actors to ensure they have a character ....' );
+				$items = ( new LWTV_Debug() )->find_actors_no_chars();
+				break;
 		}
 
 		if ( empty( $items ) || ! is_array( $items ) ) {

--- a/functions.php
+++ b/functions.php
@@ -331,18 +331,18 @@ new LWTV_Functions();
 /*
  * Add-Ons.
  */
-require_once 'features/_main.php';  // This has to be at the top.
+require_once 'features/_main.php';     // General Features: This has to be at the top.
 
-require_once 'admin/_main.php';
-require_once 'affiliates/_main.php';
-require_once 'assets/symbolicons.php';
-require_once 'blocks/_main.php';
-require_once 'plugins/_main.php';
-require_once 'rest-api/_main.php';
-require_once 'statistics/_main.php';
-require_once 'this-year/_main.php';
+require_once 'admin/_main.php';        // Admin Settings
+require_once 'affiliates/_main.php';   // Affiliates and Where to Watch
+require_once 'assets/symbolicons.php'; // Symbolicons/Font Icons
+require_once 'blocks/_main.php';       // Custom Blocks
+require_once 'plugins/_main.php';      // Tweaks for Plugins
+require_once 'rest-api/_main.php';     // Our Rest API
+require_once 'statistics/_main.php';   // Stats
+require_once 'this-year/_main.php';    // This Year
 
-require_once 'cpts/_main.php';       // This has to be at the end.
+require_once 'cpts/_main.php';         // Custom Post Types: This has to be at the end.
 
 /*
  * Composer

--- a/readme.md
+++ b/readme.md
@@ -193,9 +193,10 @@ The file `_main.php` acts as an autoloader.
 * `/cmb2/` - CMB2 add on libraries
     - `/cmb-field-select2/` - CMB2 Field Type: Select2 (forked)
     - `/cmb2-grid/` - CMB2 Grid Display
+    - `/cmb2-post-search-field/` - CMB2 Post Search (forked)
     - `/cmb2.css` - Custom CSS
     - `/lwtv.php` - Special code for us -- Favourite shows for author profiles, Symbolicon support
-    - Year Range: `/year-range.php` - 'date_year_range' custom field type
+    - `/year-range.php` - Year Range -- 'date_year_range' custom field type
 * `comment_probation.php` - Fork of abandoned plugin
 * `/facet.php` -- Facet WP
     - calls other files
@@ -209,15 +210,14 @@ The file `_main.php` acts as an autoloader.
         - split actors and shows into separate entries, and add additional orderby params
 * `gravity-forms.php` - Protection from spammers via disallowed keys
 * `/gravity-forms/` - Gravity Forms Folder
-    - `class-gf-approvals.php` - Backend code
-* `imagify.php`  - Imagify integration
-    - prevents GIFs from being processed.
+    - `class-gf-approvals.php` - Approval Code (forked from another plugin)
 * `jetpack.php`  - Jetpack integration
     - Adds Post Type to sort.
     - Show Feedback in "Right Now"
     - Custom Icon for Feedback in "Right Now"
     - Mark feedbacks as having been answered
     - Protection from spammers via disallowed keys
+* `varnish.php` - Generate a list of special URLs to flush per post type.
 
 ### Rest API
 
@@ -230,7 +230,9 @@ Stored in `/rest-api/` - These files generate the REST API output.
     - On This Day - "On this day, X died"
     - When Died - "X died on date Y"
 * `export-json.php` - Export content in JSON format. Mostly used for WikiData and Universities.
-* `imdb.php`- API to communicate with IMDb and generate information (used by Alexa)
+* `fresh.php` - Generates 'whats new' content
+* `imdb.php` - API to communicate with IMDb and generate information (used by Alexa)
+* `list.php` - Generates lists
 * `of-the-day.php` - X Of The Day API service. Every 24 hours, a new character and show of the day are spawned
 * `shows-like-this.php` - Similar shows.
 * `slack.php` - Beginning of code to report newly dead characters to Slack _(very buggy, currently disabled)_
@@ -269,7 +271,7 @@ Stored in `/statistics/` - These files generate everything for stats, from graph
     - `function dead_meta_tax()` - Generate array to parse taxonomy content as it relates to post metas (for dead characters)
     - `function meta()` - Generate array to parse post meta data
     - `function yes_no()` - Generates arrays for content that has Yes/No values (shows we love, on air)
-    - `function taxonomy_breakdowns()` - generates complex arrays of cross related data from multiple taxonomies to list 'all miniseres in the USA' (this one makes us cry)
+    - `function taxonomy_breakdowns()` - generates complex arrays of cross related data from multiple taxonomies to list 'all miniseries in the USA' (this one makes us cry)
     - `function dead_basic()` - Simple counts of all shows with dead, or all dead characters
     - `function dead_year()` - Simple counts of death by year (Sara Lance...)
     - `function on_air()` - Shows or characters on air per year

--- a/rest-api/export-json.php
+++ b/rest-api/export-json.php
@@ -325,66 +325,66 @@ class LWTV_Export_JSON {
 	 */
 	public function get_full_list_characters( $group, $term ) {
 		$the_loop   = ( new LWTV_Loops() )->tax_query( 'post_type_characters', 'lez_' . $group, 'slug', $term );
-		$characters = array();
 
 		if ( $the_loop->have_posts() ) {
-			while ( $the_loop->have_posts() ) {
-				$the_loop->the_post();
-				$post = get_post();
-
-				// Gender -- array of all applicable
-				$gender       = array();
-				$gender_terms = get_the_terms( $post->ID, 'lez_gender', true );
-				if ( $gender_terms && ! is_wp_error( $gender_terms ) ) {
-					foreach ( $gender_terms as $gender_term ) {
-						$gender[] = $gender_term->name;
-					}
-				}
-
-				// Sexuality -- array of all applicable
-				$sexuality       = array();
-				$sexuality_terms = get_the_terms( $post->ID, 'lez_sexuality', true );
-				if ( $sexuality_terms && ! is_wp_error( $sexuality_terms ) ) {
-					foreach ( $sexuality_terms as $sexuality_term ) {
-						$sexuality[] = $sexuality_term->name;
-					}
-				}
-
-				// Cliches -- array of all applicable
-				$cliches     = array();
-				$lez_cliches = get_the_terms( $post->ID, 'lez_cliches' );
-				if ( $lez_cliches && ! is_wp_error( $lez_cliches ) ) {
-					foreach ( $lez_cliches as $the_cliche ) {
-						$cliches[] = $the_cliche->name;
-					}
-				}
-				$cliches_clean = implode( '; ', $cliches );
-
-				// Shows
-				$shows_full  = get_post_meta( $post->ID, 'lezchars_show_group', true );
-				$shows_array = array();
-				foreach ( $shows_full as $show ) {
-					$appears = implode( ';', $show['appears'] );
-					$shows_array[] = get_the_title( $show['show'] ) . ' - ' . $show['type'] . ' (' . $appears . ')';
-				}
-				$shows_clean = implode( '; ', $shows_array );
-
-				$characters[ $post->post_name ] = array(
-					'id'        => $post->ID,
-					'name'      => $post->post_title,
-					'url'       => home_url( '/character/' ) . $post->post_name,
-					'image'     => wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) ),
-					'sexuality' => $sexuality,
-					'gender'    => $gender,
-					'cliches'   => $cliches_clean,
-					'shows'     => $shows_clean,
-				);
-			}
-
+			$characters_list = wp_list_pluck( $the_loop->posts, 'ID' );
 			wp_reset_query();
 		}
 
-		if ( ! isset( $characters ) ) {
+		// Make empty array for later
+		$characters = array();
+
+		foreach ( $characters_list as $character ) {
+			// Gender -- array of all applicable
+			$gender       = array();
+			$gender_terms = get_the_terms( $character, 'lez_gender', true );
+			if ( $gender_terms && ! is_wp_error( $gender_terms ) ) {
+				foreach ( $gender_terms as $gender_term ) {
+					$gender[] = $gender_term->name;
+				}
+			}
+
+			// Sexuality -- array of all applicable
+			$sexuality       = array();
+			$sexuality_terms = get_the_terms( $character, 'lez_sexuality', true );
+			if ( $sexuality_terms && ! is_wp_error( $sexuality_terms ) ) {
+				foreach ( $sexuality_terms as $sexuality_term ) {
+					$sexuality[] = $sexuality_term->name;
+				}
+			}
+
+			// Cliches -- array of all applicable
+			$cliches     = array();
+			$lez_cliches = get_the_terms( $character, 'lez_cliches' );
+			if ( $lez_cliches && ! is_wp_error( $lez_cliches ) ) {
+				foreach ( $lez_cliches as $the_cliche ) {
+					$cliches[] = $the_cliche->name;
+				}
+			}
+			$cliches_clean = implode( '; ', $cliches );
+
+			// Shows
+			$shows_full  = get_post_meta( $character, 'lezchars_show_group', true );
+			$shows_array = array();
+			foreach ( $shows_full as $show ) {
+				$appears = implode( ';', $show['appears'] );
+				$shows_array[] = get_the_title( $show['show'] ) . ' - ' . $show['type'] . ' (' . $appears . ')';
+			}
+			$shows_clean = implode( '; ', $shows_array );
+
+			$characters[ $post->post_name ] = array(
+				'id'        => $post->ID,
+				'name'      => $post->post_title,
+				'url'       => home_url( '/character/' ) . $post->post_name,
+				'image'     => wp_get_attachment_url( get_post_thumbnail_id( $post->ID ) ),
+				'sexuality' => $sexuality,
+				'gender'    => $gender,
+				'cliches'   => $cliches_clean,
+				'shows'     => $shows_clean,
+			);
+		}
+
+		if ( ! isset( $characters ) || empty( $characters ) ) {
 			return new WP_Error( 'not_found', 'No route was found matching the URL and request method: ' . $term );
 		} else {
 			return $characters;

--- a/rest-api/stats.php
+++ b/rest-api/stats.php
@@ -204,20 +204,20 @@ class LWTV_Stats_JSON {
 				$queery = ( new LWTV_Loops() )->post_type_query( 'post_type_actors', $page );
 
 				if ( $queery->have_posts() ) {
-					while ( $queery->have_posts() ) {
-						$queery->the_post();
-						$post                                      = get_post();
-						$stats_array[ get_the_title( $post->ID ) ] = array(
-							'id'         => $post->ID,
-							'characters' => get_post_meta( $post->ID, 'lezactors_char_count', true ),
-							'dead_chars' => get_post_meta( $post->ID, 'lezactors_dead_count', true ),
-							'gender'     => implode( ', ', wp_get_post_terms( $post->ID, 'lez_actor_gender', array( 'fields' => 'names' ) ) ),
-							'sexuality'  => implode( ', ', wp_get_post_terms( $post->ID, 'lez_actor_sexuality', array( 'fields' => 'names' ) ) ),
-							'queer'      => ( new LWTV_Loops() )->is_actor_queer( $post->ID ),
-							'url'        => get_the_permalink( $post->ID ),
-						);
-					}
+					$actors = wp_list_pluck( $queery->posts, 'ID' );
 					wp_reset_query();
+				}
+
+				foreach ( $actors as $actor ) {
+					$stats_array[ get_the_title( $actor ) ] = array(
+						'id'         => $actor,
+						'characters' => get_post_meta( $actor, 'lezactors_char_count', true ),
+						'dead_chars' => get_post_meta( $actor, 'lezactors_dead_count', true ),
+						'gender'     => implode( ', ', wp_get_post_terms( $actor, 'lez_actor_gender', array( 'fields' => 'names' ) ) ),
+						'sexuality'  => implode( ', ', wp_get_post_terms( $actor, 'lez_actor_sexuality', array( 'fields' => 'names' ) ) ),
+						'queer'      => ( new LWTV_Loops() )->is_actor_queer( $actor ),
+						'url'        => get_the_permalink( $actor ),
+					);
 				}
 				break;
 			case 'simple':
@@ -275,47 +275,47 @@ class LWTV_Stats_JSON {
 			case 'complex':
 				$stats_array    = array();
 				$charactersloop = ( new LWTV_Loops() )->post_type_query( 'post_type_characters', $page );
+
 				if ( $charactersloop->have_posts() ) {
-					while ( $charactersloop->have_posts() ) {
-						$charactersloop->the_post();
-
-						$post   = get_post();
-						$died   = get_post_meta( $post->ID, 'lezchars_death_year', true );
-						$died   = ( ! is_array( $died ) ) ? array( $died ) : $died;
-						$shows  = count( get_post_meta( $post->ID, 'lezchars_show_group', true ) );
-						$actors = count( get_post_meta( $post->ID, 'lezchars_actor', true ) );
-						$gender = implode(
-							', ',
-							wp_get_post_terms(
-								$post->ID,
-								'lez_gender',
-								array(
-									'fields' => 'names',
-								)
-							)
-						);
-						$sexual = implode(
-							', ',
-							wp_get_post_terms(
-								$post->ID,
-								'lez_sexuality',
-								array(
-									'fields' => 'names',
-								)
-							)
-						);
-
-						$stats_array[ get_the_title() ] = array(
-							'id'        => $post->ID,
-							'died'      => $died,
-							'actors'    => $actors,
-							'shows'     => $shows,
-							'gender'    => $gender,
-							'sexuality' => $sexual,
-							'url'       => get_the_permalink(),
-						);
-					}
+					$characters = wp_list_pluck( $charactersloop->posts, 'ID' );
 					wp_reset_query();
+				}
+
+				foreach ( $characters as $character ) {
+					$died   = get_post_meta( $character, 'lezchars_death_year', true );
+					$died   = ( ! is_array( $died ) ) ? array( $died ) : $died;
+					$shows  = count( get_post_meta( $character, 'lezchars_show_group', true ) );
+					$actors = count( get_post_meta( $character, 'lezchars_actor', true ) );
+					$gender = implode(
+						', ',
+						wp_get_post_terms(
+							$character,
+							'lez_gender',
+							array(
+								'fields' => 'names',
+							)
+						)
+					);
+					$sexual = implode(
+						', ',
+						wp_get_post_terms(
+							$character,
+							'lez_sexuality',
+							array(
+								'fields' => 'names',
+							)
+						)
+					);
+
+					$stats_array[ get_the_title() ] = array(
+						'id'        => $character,
+						'died'      => $died,
+						'actors'    => $actors,
+						'shows'     => $shows,
+						'gender'    => $gender,
+						'sexuality' => $sexual,
+						'url'       => get_the_permalink(),
+					);
 				}
 				break;
 			case 'simple':
@@ -449,27 +449,28 @@ class LWTV_Stats_JSON {
 				break;
 			case 'complex':
 				$showsloop = ( new LWTV_Loops() )->post_type_query( 'post_type_shows', $page );
-				if ( $showsloop->have_posts() ) {
-					while ( $showsloop->have_posts() ) {
-						$showsloop->the_post();
-						$post                                      = get_post();
-						$stats_array[ get_the_title( $post->ID ) ] = array(
-							'id'              => $post->ID,
-							'nations'         => implode( ', ', wp_get_post_terms( $post->ID, 'lez_country', array( 'fields' => 'names' ) ) ),
-							'stations'        => implode( ', ', wp_get_post_terms( $post->ID, 'lez_stations', array( 'fields' => 'names' ) ) ),
 
-							'worth_it'        => get_post_meta( $post->ID, 'lezshows_worthit_rating', true ),
-							'trigger'         => implode( ', ', wp_get_post_terms( $post->ID, 'lez_triggers', array( 'fields' => 'names' ) ) ),
-							'star'            => implode( ', ', wp_get_post_terms( $post->ID, 'lez_stars', array( 'fields' => 'names' ) ) ),
-							'loved'           => ( ( get_post_meta( $post->ID, 'lezshows_worthit_show_we_love', true ) ) ? 'yes' : 'no' ),
-							'chars_total'     => get_post_meta( $post->ID, 'lezshows_char_count', true ),
-							'chars_dead'      => get_post_meta( $post->ID, 'lezshows_dead_count', true ),
-							'chars_sexuality' => get_post_meta( $post->ID, 'lezshows_char_sexuality', true ),
-							'chars_gender'    => get_post_meta( $post->ID, 'lezshows_char_gender', true ),
-							'url'             => get_the_permalink( $post->ID ),
-						);
-					}
+				if ( $showsloop->have_posts() ) {
+					$shows = wp_list_pluck( $showsloop->posts, 'ID' );
 					wp_reset_query();
+				}
+
+				foreach ( $shows as $show ) {
+					$stats_array[ get_the_title( $show ) ] = array(
+						'id'              => $show,
+						'nations'         => implode( ', ', wp_get_post_terms( $show, 'lez_country', array( 'fields' => 'names' ) ) ),
+						'stations'        => implode( ', ', wp_get_post_terms( $show, 'lez_stations', array( 'fields' => 'names' ) ) ),
+
+						'worth_it'        => get_post_meta( $show, 'lezshows_worthit_rating', true ),
+						'trigger'         => implode( ', ', wp_get_post_terms( $show, 'lez_triggers', array( 'fields' => 'names' ) ) ),
+						'star'            => implode( ', ', wp_get_post_terms( $show, 'lez_stars', array( 'fields' => 'names' ) ) ),
+						'loved'           => ( ( get_post_meta( $show, 'lezshows_worthit_show_we_love', true ) ) ? 'yes' : 'no' ),
+						'chars_total'     => get_post_meta( $show, 'lezshows_char_count', true ),
+						'chars_dead'      => get_post_meta( $show, 'lezshows_dead_count', true ),
+						'chars_sexuality' => get_post_meta( $show, 'lezshows_char_sexuality', true ),
+						'chars_gender'    => get_post_meta( $show, 'lezshows_char_gender', true ),
+						'url'             => get_the_permalink( $show ),
+					);
 				}
 				break;
 			case 'simple':
@@ -648,56 +649,56 @@ class LWTV_Stats_JSON {
 			// Get the posts for this singular term (i.e. a specific station)
 			$queery = ( new LWTV_Loops() )->tax_query( 'post_type_shows', 'lez_' . $type, 'slug', $slug, 'IN' );
 
-			// If we have anyone assigned to this station/nation, let's process
 			if ( $queery->have_posts() ) {
-				foreach ( $queery->posts as $show ) {
+				$shows_queery = wp_list_pluck( $queery->posts, 'ID' );
+				wp_reset_query();
+			}
 
-					// Increase the show count
-					$shows++;
-					$dead       += get_post_meta( $show->ID, 'lezshows_dead_count', true );
-					$characters += get_post_meta( $show->ID, 'lezshows_char_count', true );
+			foreach ( $shows_queery as $show_id ) {
 
-					// Get the sub taxonomy counts based on post meta
+				// Increase the show count
+				$shows++;
+				$dead       += get_post_meta( $show_id, 'lezshows_dead_count', true );
+				$characters += get_post_meta( $show_id, 'lezshows_char_count', true );
+
+				// Get the sub taxonomy counts based on post meta
+				foreach ( $valid_subtaxes as $meta ) {
+					$char_data_array    = get_post_meta( $show_id, 'lezshows_char_' . $meta );
+					$char_data[ $meta ] = array_shift( $char_data_array );
+				}
+
+				// If we have a complex format, let's get ALL the data too!
+				if ( 'complex' === $format ) {
 					foreach ( $valid_subtaxes as $meta ) {
-						$char_data_array    = get_post_meta( $show->ID, 'lezshows_char_' . $meta );
-						$char_data[ $meta ] = array_shift( $char_data_array );
-					}
-
-					// If we have a complex format, let's get ALL the data too!
-					if ( 'complex' === $format ) {
-						foreach ( $valid_subtaxes as $meta ) {
-							$char_data_array = get_post_meta( $show->ID, 'lezshows_char_' . $meta );
-							foreach ( array_shift( $char_data_array ) as $char_data_meta => $char_data_count ) {
-								$char_data[ $char_data_meta ] += $char_data_count;
-								unset( $char_data[ $meta ] );
-							}
-						}
-					}
-
-					// Build our return array
-					// Show Count
-					$return[ $slug ]['shows'] = $shows;
-
-					// Only run this if we're complex...
-					if ( 'complex' === $format ) {
-						$return[ $slug ]['onair']           = ( new LWTV_Stats() )->showcount( 'onair', $type, $slug );
-						$return[ $slug ]['avg_score']       = ( new LWTV_Stats() )->showcount( 'score', $type, $slug );
-						$return[ $slug ]['avg_onair_score'] = ( new LWTV_Stats() )->showcount( 'onairscore', $type, $slug );
-					}
-
-					// Character counts
-					$return[ $slug ]['characters'] = $characters;
-					$return[ $slug ]['dead']       = $dead;
-
-					// If we have a complex format, we need to add that data...
-					if ( 'complex' === $format ) {
-						foreach ( $char_data as $ctax_name => $ctax_count ) {
-							$return[ $slug ][ $ctax_name ] = $ctax_count;
+						$char_data_array = get_post_meta( $show_id, 'lezshows_char_' . $meta );
+						foreach ( array_shift( $char_data_array ) as $char_data_meta => $char_data_count ) {
+							$char_data[ $char_data_meta ] += $char_data_count;
+							unset( $char_data[ $meta ] );
 						}
 					}
 				}
 
-				wp_reset_query();
+				// Build our return array
+				// Show Count
+				$return[ $slug ]['shows'] = $shows;
+
+				// Only run this if we're complex...
+				if ( 'complex' === $format ) {
+					$return[ $slug ]['onair']           = ( new LWTV_Stats() )->showcount( 'onair', $type, $slug );
+					$return[ $slug ]['avg_score']       = ( new LWTV_Stats() )->showcount( 'score', $type, $slug );
+					$return[ $slug ]['avg_onair_score'] = ( new LWTV_Stats() )->showcount( 'onairscore', $type, $slug );
+				}
+
+				// Character counts
+				$return[ $slug ]['characters'] = $characters;
+				$return[ $slug ]['dead']       = $dead;
+
+				// If we have a complex format, we need to add that data...
+				if ( 'complex' === $format ) {
+					foreach ( $char_data as $ctax_name => $ctax_count ) {
+						$return[ $slug ][ $ctax_name ] = $ctax_count;
+					}
+				}
 			}
 		}
 

--- a/statistics/array.php
+++ b/statistics/array.php
@@ -1370,7 +1370,7 @@ class LWTV_Stats_Arrays {
 		return $array;
 	}
 
-	/** 
+	/**
 	 * Stats for character roles per actor.
 	*/
 	public function actor_char_role( $type, $the_id ) {
@@ -1444,8 +1444,7 @@ class LWTV_Stats_Arrays {
 
 	}
 
-
-	/** 
+	/**
 	 * Stats for dead character per actor.
 	*/
 	public function actor_char_dead( $type, $the_id ) {
@@ -1507,9 +1506,9 @@ class LWTV_Stats_Arrays {
 						foreach ( $actors_array as $char_actor ) {
 							if ( $char_actor == $the_id ) {  // phpcs:ignore WordPress.PHP.StrictComparisons
 								if ( has_term( 'dead', 'lez_cliches', $char_id ) ) {
-									$base_array[ 'dead' ][ 'count']++;
+									$base_array['dead']['count']++;
 								} else {
-									$base_array[ 'alive' ][ 'count']++;
+									$base_array['alive']['count']++;
 								}
 							}
 						}

--- a/statistics/array.php
+++ b/statistics/array.php
@@ -1527,7 +1527,7 @@ class LWTV_Stats_Arrays {
 			$array = $base_array;
 
 			// save array as transient for a reason.
-			//set_transient( $transient, $array, DAY_IN_SECONDS );
+			set_transient( $transient, $array, DAY_IN_SECONDS );
 		}
 
 		return $array;

--- a/statistics/array.php
+++ b/statistics/array.php
@@ -1376,44 +1376,50 @@ class LWTV_Stats_Arrays {
 	public function actor_char_role( $type, $the_id ) {
 		// Default
 		$array     = array();
-		$post_type = 'post_type_' . $type;
+		$post_type = $type;
 
 		$transient = 'actor_char_role_' . $the_id;
 		$array     = get_transient( $transient );
-		if ( false === $array ) {
-			$base_array     = array(
+		if ( false === $array || empty( $array ) ) {
+			$base_array = array(
 				'regular'   => 0,
 				'recurring' => 0,
 				'guest'     => 0,
 			);
-			$characters     = array();
-			$charactersloop = new WP_Query(
-				array(
-					'post_type'              => 'post_type_characters',
-					'post_status'            => array( 'publish' ),
-					'orderby'                => 'title',
-					'order'                  => 'ASC',
-					'posts_per_page'         => '20',
-					'no_found_rows'          => true,
-					'update_post_term_cache' => true,
-					'meta_query'             => array(
-						array(
-							'key'     => 'lezchars_actor',
-							'value'   => $the_id,
-							'compare' => 'LIKE',
-						),
-					),
-				)
-			);
+			$characters = array();
 
-			if ( $charactersloop->have_posts() ) {
-				$char_array = wp_list_pluck( $charactersloop->posts, 'ID' );
-				wp_reset_query();
+			// Get array of characters (by ID)
+			$char_array = get_post_meta( $the_id, 'lezactors_char_list', true );
+
+			// If the character list is empty, we must build it
+			if ( empty( $char_array ) ) {
+				// Loop to get the list of characters
+				$charactersloop = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_actor', $post_id, 'LIKE' );
+
+				if ( $charactersloop->have_posts() ) {
+					$char_array = wp_list_pluck( $charactersloop->posts, 'ID' );
+					wp_reset_query();
+				}
+				$char_array = array_unique( $char_array );
+
+				foreach ( $char_array as $char_id ) {
+					$actors = get_post_meta( $char_id, 'lezchars_actor', true );
+					if ( 'publish' === get_post_status( $char_id ) && isset( $actors ) && ! empty( $actors ) ) {
+						foreach ( $actors as $actor ) {
+							// We have to check because due to so many characters, we have some actor mis-matches.
+							if ( $actor == $the_id ) {  // phpcs:ignore WordPress.PHP.StrictComparisons
+								$character_checked[] = $the_id;
+							}
+						}
+					}
+				}
+
+				$char_array = $character_checked;
+				update_post_meta( $the_id, 'lezactors_char_list', $char_array );
 			}
 
 			if ( is_array( $char_array ) ) {
 				foreach ( $char_array as $char_id ) {
-					$char_id      = get_the_ID();
 					$actors_array = get_post_meta( $char_id, 'lezchars_actor', true );
 					if ( 'publish' === get_post_status( $char_id ) && isset( $actors_array ) && ! empty( $actors_array ) ) {
 						foreach ( $actors_array as $char_actor ) {
@@ -1450,11 +1456,12 @@ class LWTV_Stats_Arrays {
 	public function actor_char_dead( $type, $the_id ) {
 		// Default
 		$array     = array();
-		$post_type = 'post_type_' . $type;
+		$post_type = $type;
 
 		$transient = 'actor_char_dead_' . $the_id;
 		$array     = get_transient( $transient );
-		if ( false === $array ) {
+
+		if ( false === $array || empty( $array ) ) {
 			$base_array     = array(
 				'alive' => array(
 					'count' => 0,
@@ -1467,40 +1474,41 @@ class LWTV_Stats_Arrays {
 					'url'   => '',
 				),
 			);
-			$characters     = array();
-			$charactersloop = new WP_Query(
-				array(
-					'post_type'              => 'post_type_characters',
-					'post_status'            => array( 'publish' ),
-					'orderby'                => 'title',
-					'order'                  => 'ASC',
-					'posts_per_page'         => '20',
-					'no_found_rows'          => true,
-					'update_post_term_cache' => true,
-					'meta_query'             => array(
-						array(
-							'key'     => 'lezchars_actor',
-							'value'   => $the_id,
-							'compare' => 'LIKE',
-						),
-					),
-					'tax_query'              => array(
-						'taxonomy' => 'lez_cliches',
-						'terms'    => 'dead',
-						'field'    => 'slug',
-						'operator' => 'IN',
-					),
-				)
-			);
 
-			if ( $charactersloop->have_posts() ) {
-				$char_array = wp_list_pluck( $charactersloop->posts, 'ID' );
-				wp_reset_query();
+			$characters = array();
+
+			// Get array of characters (by ID)
+			$char_array = get_post_meta( $the_id, 'lezactors_char_list', true );
+
+			// If the character list is empty, we must build it
+			if ( empty( $char_array ) ) {
+				// Loop to get the list of characters
+				$charactersloop = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_actor', $post_id, 'LIKE' );
+
+				if ( $charactersloop->have_posts() ) {
+					$char_array = wp_list_pluck( $charactersloop->posts, 'ID' );
+					wp_reset_query();
+				}
+				$char_array = array_unique( $char_array );
+
+				foreach ( $char_array as $char_id ) {
+					$actors = get_post_meta( $char_id, 'lezchars_actor', true );
+					if ( 'publish' === get_post_status( $char_id ) && isset( $actors ) && ! empty( $actors ) ) {
+						foreach ( $actors as $actor ) {
+							// We have to check because due to so many characters, we have some actor mis-matches.
+							if ( $actor == $the_id ) {  // phpcs:ignore WordPress.PHP.StrictComparisons
+								$character_checked[] = $the_id;
+							}
+						}
+					}
+				}
+
+				$char_array = $character_checked;
+				update_post_meta( $the_id, 'lezactors_char_list', $char_array );
 			}
 
 			if ( is_array( $char_array ) ) {
 				foreach ( $char_array as $char_id ) {
-					$char_id      = get_the_ID();
 					$actors_array = get_post_meta( $char_id, 'lezchars_actor', true );
 					if ( 'publish' === get_post_status( $char_id ) && isset( $actors_array ) && ! empty( $actors_array ) ) {
 						foreach ( $actors_array as $char_actor ) {

--- a/statistics/templates/formats.php
+++ b/statistics/templates/formats.php
@@ -88,7 +88,7 @@ switch ( $showform ) {
 			echo '<li class="nav-item"><a class="nav-link' . esc_attr( $active ) . '" href="' . esc_url( add_query_arg( $query_arg, $baseurl . $the_view . '/' ) ) . '">' . esc_html( strtoupper( str_replace( '-', ' ', $the_view ) ) ) . '</a></li>';
 		}
 	}
-?>
+	?>
 </ul>
 
 <p>&nbsp;</p>
@@ -111,6 +111,7 @@ switch ( $showform ) {
 
 		if ( '_all' === $showform ) {
 			if ( '_all' === $view ) {
+				$all_count = ( new LWTV_Stats() )->showcount( 'score', 'formats', $a_form->slug );
 				?>
 				<p>For more information on individual show formats, please use the dropdown menu, or click on a format type listed below.</p>
 				<table id="formatTable" class="tablesorter table table-striped table-hover">
@@ -130,7 +131,7 @@ switch ( $showform ) {
 							<th scope="row"><a href="?showform=' . esc_attr( $a_form->slug ) . '">' . esc_html( $a_form->name ) . '</a></th>
 							<td>' . (int) $a_form->count . '</td>
 							<td><div class="progress"><div class="progress-bar bg-info" role="progressbar" style="width: ' . esc_html( $percent ) . '%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div></div>&nbsp;' . esc_html( $percent ) . '%</td>
-							<td>' . (int) ( new LWTV_Stats() )->showcount( 'score', 'formats', $a_form->slug ) . '</td>
+							<td>' . (int) $all_count . '</td>
 						</tr>';
 					}
 					?>
@@ -159,9 +160,10 @@ switch ( $showform ) {
 			$allshows   = ( new LWTV_Stats() )->showcount( 'total', 'formats', ltrim( $showform, '_' ) );
 			$showscore  = ( new LWTV_Stats() )->showcount( 'score', 'formats', ltrim( $showform, '_' ) );
 			$onairscore = ( new LWTV_Stats() )->showcount( 'onairscore', 'formats', ltrim( $showform, '_' ) );
+			$type_name  = ( ! str_ends_with( $showform_obj['name'], 's' ) ) ? $showform_obj['name'] . 's' : $showform_obj['name'];
 
 			if ( '_all' === $view ) {
-				echo wp_kses_post( '<p>Currently, ' . $onair . ' of ' . $allshows . ' ' . $showform_obj['name'] . 's are on air. The average score for all ' . $showform_obj['name'] . 's is ' . $showscore . ', and ' . $onairscore . ' for ' . $showform_obj['name'] . 's currently on air (out of a possible 100).</p>' );
+				echo wp_kses_post( '<p>Currently, ' . $onair . ' of ' . $allshows . ' ' . $type_name . ' are on air. The average score for all ' . $type_name . ' is ' . $showscore . ', and ' . $onairscore . ' for ' . $showform_obj['name'] . 's currently on air (out of a possible 100).</p>' );
 			}
 
 			( new LWTV_Stats() )->generate( $cpts_type, 'formats' . $showform . $view, $format );

--- a/statistics/templates/nations.php
+++ b/statistics/templates/nations.php
@@ -112,6 +112,7 @@ switch ( $country ) {
 
 		if ( '_all' === $country ) {
 			// Always show the same thing here.
+			$all_count = ( new LWTV_Stats() )->showcount( 'score', 'country', $nation->slug );
 			?>
 			<p>For more information on individual nations, please use the dropdown menu, or click on a nation listed below.</p>
 			<table id="nationsTable" class="tablesorter table table-striped table-hover">
@@ -131,7 +132,7 @@ switch ( $country ) {
 						<th scope="row"><a href="?country=' . esc_attr( $nation->slug ) . '">' . esc_html( $nation->name ) . '</a></th>
 						<td>' . (int) $nation->count . '</td>
 						<td><div class="progress"><div class="progress-bar bg-info" role="progressbar" style="width: ' . esc_html( $percent ) . '%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div></div>&nbsp;' . esc_html( $percent ) . '%</td>
-						<td>' . (int) ( new LWTV_Stats() )->showcount( 'score', 'country', $nation->slug ) . '</td>
+						<td>' . (int) $all_count . '</td>
 					</tr>';
 				}
 				?>

--- a/statistics/templates/post_type_actors.php
+++ b/statistics/templates/post_type_actors.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * The template for displaying the mini stats section on Actor Pages
- * 
+ *
  * I don't like how it formats with the height...
  *
  * @package LezWatch.TV

--- a/statistics/templates/stations.php
+++ b/statistics/templates/stations.php
@@ -15,7 +15,7 @@ $valid_views = array(
 	'sexuality' => 'characters',
 	'gender'    => 'characters',
 	'tropes'    => 'shows',
-	// removed becuase there's not enough data yet.
+	// removed because there's not enough data yet.
 	// 'intersections' => 'shows',
 	'formats'   => 'shows',
 	'on-air'    => 'shows',
@@ -105,6 +105,7 @@ switch ( $station ) {
 
 		if ( '_all' === $station ) {
 			// Always show the same thing here.
+			$all_count = ( new LWTV_Stats() )->showcount( 'score', 'stations', $the_station->slug );
 			?>
 			<p>For more information on individual stations, please use the dropdown menu, or click on a station listed below.</p>
 			<table id="stationsTable" class="tablesorter table table-striped table-hover">
@@ -124,7 +125,7 @@ switch ( $station ) {
 								<th scope="row"><a href="?station=' . esc_attr( $the_station->slug ) . '">' . esc_html( $the_station->name ) . '</a></th>
 								<td>' . (int) $the_station->count . '</td>
 								<td><div class="progress"><div class="progress-bar bg-info" role="progressbar" style="width: ' . esc_html( $percent ) . '%;" aria-valuenow="25" aria-valuemin="0" aria-valuemax="100"></div></div>&nbsp;' . esc_html( $percent ) . '%</td>
-								<td>' . (int) ( new LWTV_Stats() )->showcount( 'score', 'stations', $the_station->slug ) . '</td>
+								<td>' . (int) $all_count . '</td>
 							</tr>';
 					}
 					?>

--- a/this-year/_main.php
+++ b/this-year/_main.php
@@ -143,8 +143,8 @@ class LWTV_This_Year {
 				// If it's not 1961, we can show the first year we have queers
 				if ( $thisyear !== $lastyear ) {
 					?>
-					<li class="page-item first mr-auto"><a href="<?php echo esc_url( $baseurl . $lastyear . '/' . $view ); ?>" class="page-link"><?php echo ( new LWTV_Functions() )->symbolicons( 'caret-left-circle.svg', 'fa-chevron-circle-left' ); ?> First (<?php echo (int) $lastyear; ?>)</a></li>
-					<li class="page-item"><a href="<?php echo esc_url( $baseurl . ( $thisyear - 1 ) . '/' . $view ); ?>" title="previous year" class="page-link"><?php echo ( new LWTV_Functions() )->symbolicons( 'caret-left.svg', 'fa-chevron-left' ); ?> Previous</a></li>
+					<li class="page-item first mr-auto"><a href="<?php echo esc_url( $baseurl . $lastyear . '/' . $view ); ?>" class="page-link"><?php echo ( new LWTV_Functions() )->symbolicons( 'caret-left-circle.svg', 'fa-chevron-circle-left' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> First (<?php echo (int) $lastyear; ?>)</a></li> 
+					<li class="page-item"><a href="<?php echo esc_url( $baseurl . ( $thisyear - 1 ) . '/' . $view ); ?>" title="previous year" class="page-link"><?php echo ( new LWTV_Functions() )->symbolicons( 'caret-left.svg', 'fa-chevron-left' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?> Previous</a></li>
 					<li class="page-item"><a href="<?php echo esc_url( $baseurl . ( $thisyear - 2 ) . '/' . $view ); ?>" class="page-link"><?php echo (int) ( $thisyear - 2 ); ?></a></li>
 					<li class="page-item"><a href="<?php echo esc_url( $baseurl . ( $thisyear - 1 ) . '/' . $view ); ?>" class="page-link"><?php echo (int) ( $thisyear - 1 ); ?></a></li>
 					<?php
@@ -157,8 +157,8 @@ class LWTV_This_Year {
 				if ( gmdate( 'Y' ) !== $thisyear ) {
 					?>
 					<li class="page-item"><a href="<?php echo esc_url( $baseurl . ( $thisyear + 1 ) . '/' . $view ); ?>" class="page-link"><?php echo (int) ( $thisyear + 1 ); ?></a></li>
-					<li class="page-item"><a href="<?php echo esc_url( $baseurl . ( $thisyear + 1 ) . '/' . $view ); ?>" class="page-link" title="next year">Next <?php echo ( new LWTV_Functions() )->symbolicons( 'caret-right.svg', 'fa-chevron-right' ); ?></a></li>
-					<li class="page-item last ml-auto"><a href="<?php echo esc_url( $baseurl . gmdate( 'Y' ) . '/' . $view ); ?>" class="page-link">Last (<?php echo (int) gmdate( 'Y' ); ?>) <?php echo ( new LWTV_Functions() )->symbolicons( 'caret-right-circle.svg', 'fa-chevron-circle-right' ); ?></a></li>
+					<li class="page-item"><a href="<?php echo esc_url( $baseurl . ( $thisyear + 1 ) . '/' . $view ); ?>" class="page-link" title="next year">Next <?php echo ( new LWTV_Functions() )->symbolicons( 'caret-right.svg', 'fa-chevron-right' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></a></li>
+					<li class="page-item last ml-auto"><a href="<?php echo esc_url( $baseurl . gmdate( 'Y' ) . '/' . $view ); ?>" class="page-link">Last (<?php echo (int) gmdate( 'Y' ); ?>) <?php echo ( new LWTV_Functions() )->symbolicons( 'caret-right-circle.svg', 'fa-chevron-circle-right' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></a></li>
 					<?php
 				}
 				?>

--- a/this-year/characters.php
+++ b/this-year/characters.php
@@ -171,14 +171,20 @@ class LWTV_This_Year_Chars {
 	 * @return array             All the data you need.
 	 */
 	public function get_dead( $thisyear, $count = false ) {
-		$thisyear   = ( isset( $thisyear ) ) ? $thisyear : gmdate( 'Y' );
-		$dead_loop  = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_death_year', $thisyear, 'REGEXP' );
-		$queery     = wp_list_pluck( $dead_loop->posts, 'ID' );
+		$return_array = array();
+		$thisyear     = ( isset( $thisyear ) ) ? $thisyear : gmdate( 'Y' );
+		$dead_loop    = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_death_year', $thisyear, 'REGEXP' );
+
+		if ( $dead_loop->have_posts() ) {
+			$queery = wp_list_pluck( $dead_loop->posts, 'ID' );
+			wp_reset_query();
+		}
+
 		$show_array = array();
 		$list_array = array();
 
 		// List all queers and the year they died
-		if ( $dead_loop->have_posts() ) {
+		if ( isset( $queery ) && is_array( $queery ) ) {
 			foreach ( $queery as $char ) {
 				$show_ids_raw = get_post_meta( $char, 'lezchars_show_group', true );
 				$show_title   = array();
@@ -260,17 +266,17 @@ class LWTV_This_Year_Chars {
 			ksort( $show_array );
 		}
 
-		wp_reset_query();
-
-		// if we counted, just kick that back.
-		if ( $count ) {
-			$return_array = count( $queery );
-		} else {
-			$return_array = array(
-				'count' => count( $queery ),
-				'list'  => $list_array,
-				'show'  => $show_array,
-			);
+		if ( isset( $queery ) ) {
+			// if we counted, just kick that back.
+			if ( $count ) {
+				$return_array = count( $queery );
+			} else {
+				$return_array = array(
+					'count' => count( $queery ),
+					'list'  => $list_array,
+					'show'  => $show_array,
+				);
+			}
 		}
 
 		return $return_array;
@@ -286,12 +292,17 @@ class LWTV_This_Year_Chars {
 	public function get_list( $thisyear, $count = false ) {
 		$thisyear      = ( isset( $thisyear ) ) ? $thisyear : gmdate( 'Y' );
 		$loop          = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_show_group', $thisyear, 'REGEXP' );
-		$queery        = wp_list_pluck( $loop->posts, 'ID' );
+
+		if ( $loop->have_posts() ) {
+			$queery = wp_list_pluck( $loop->posts, 'ID' );
+			wp_reset_query();
+		}
+
 		$counted_chars = 0;
 		$show_array    = array();
 		$char_array    = array();
 
-		if ( $loop->have_posts() ) {
+		if ( is_array( $queery ) ) {
 			foreach ( $queery as $char ) {
 				$show_ids   = get_post_meta( $char, 'lezchars_show_group', true );
 				$show_title = array();
@@ -347,8 +358,6 @@ class LWTV_This_Year_Chars {
 				}
 			}
 		}
-
-		wp_reset_query();
 
 		// if we counted, just kick that back.
 		if ( $count ) {

--- a/this-year/characters.php
+++ b/this-year/characters.php
@@ -15,10 +15,11 @@ class LWTV_This_Year_Chars {
 	public function dead( $thisyear ) {
 		$thisyear   = ( isset( $thisyear ) ) ? $thisyear : gmdate( 'Y' );
 		$char_array = self::get_dead( $thisyear );
-		$list_array = $char_array['list'];
-		$show_array = $char_array['show'];
+		$count      = ( isset( $char_array['count'] ) ) ? $char_array['list'] : '0';
+		$list_array = ( isset( $char_array['list'] ) ) ? $char_array['list'] : '';
+		$show_array = ( isset( $char_array['show'] ) ) ? $char_array['show'] : '';
 		?>
-		<h2><a name="died"><?php echo (int) $char_array['count']; ?> Characters Died</a></h2>
+		<h2><a name="died"><?php echo (int) $count; ?> Characters Died</a></h2>
 
 		<p>&nbsp;</p>
 

--- a/this-year/characters.php
+++ b/this-year/characters.php
@@ -291,8 +291,8 @@ class LWTV_This_Year_Chars {
 	 * @return array             All the data you need.
 	 */
 	public function get_list( $thisyear, $count = false ) {
-		$thisyear      = ( isset( $thisyear ) ) ? $thisyear : gmdate( 'Y' );
-		$loop          = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_show_group', $thisyear, 'REGEXP' );
+		$thisyear = ( isset( $thisyear ) ) ? $thisyear : gmdate( 'Y' );
+		$loop     = ( new LWTV_Loops() )->post_meta_query( 'post_type_characters', 'lezchars_show_group', $thisyear, 'REGEXP' );
 
 		if ( $loop->have_posts() ) {
 			$queery = wp_list_pluck( $loop->posts, 'ID' );

--- a/this-year/shows.php
+++ b/this-year/shows.php
@@ -381,9 +381,12 @@ class LWTV_This_Year_Shows {
 		$shows_queery  = ( new LWTV_Loops() )->post_type_query( 'post_type_shows' );
 
 		if ( $shows_queery->have_posts() ) {
-			while ( $shows_queery->have_posts() ) {
-				$shows_queery->the_post();
-				$show_id   = get_the_ID();
+			$shows_array = wp_list_pluck( $shows_queery->posts, 'ID' );
+			wp_reset_query();
+		}
+
+		if ( is_array( $shows_array ) ) {
+			foreach ( $shows_array as $show_id ) {
 				$show_name = preg_replace( '/\s*/', '', get_the_title( $show_id ) );
 				$show_name = strtolower( $show_name );
 				$yes_count = false;
@@ -454,8 +457,6 @@ class LWTV_This_Year_Shows {
 				}
 			}
 		}
-
-		wp_reset_query();
 
 		// if we counted, just kick that back.
 		if ( $count ) {


### PR DESCRIPTION
Given the volume of data, doing constant SQL calls and loops is dogging the system.

In order to speed things up, characters will update term meta for actors and shows when updated, keeping an array of post IDs, which will be used to generate all sorts of things from stats to how characters are displayed on pages for shows/actors.

Instead of trying to loop and process everything as a post, we're going to loop to get the IDs **only if** that post_meta doesn't exist, and then use the IDs and get_post_meta() etc.

There are also a bunch of PHCS fixes, as well as a sneaky fix for an invisible error.