### PR TITLE
Creates an editor only button to refresh cache and recalculate a page.

### DIFF
--- a/php/_components/class-theme.php
+++ b/php/_components/class-theme.php
@@ -260,10 +260,16 @@ class Theme implements Component, Templater {
 	/**
 	 * Do the Math
 	 *
+	 * If a user is NOT logged in, and this got called, re-run the math.
+	 * This is to prevent the math from being run on every page load, since
+	 * we have a lot of caching.
+	 *
 	 * @param  int $post_id
 	 * @return void
 	 */
 	public function generate_the_math( $post_id ): void {
-		( new Do_Math() )->make( $post_id );
+		if ( ! is_user_logged_in() ) {
+			( new Do_Math() )->make( $post_id );
+		}
 	}
 }

--- a/php/_components/class-theme.php
+++ b/php/_components/class-theme.php
@@ -59,7 +59,7 @@ class Theme implements Component, Templater {
 			'get_actor_dead'            => array( $this, 'get_actor_dead' ),
 			'get_actor_age'             => array( $this, 'get_actor_age' ),
 			'get_actor_birthday'        => array( $this, 'get_actor_birthday' ),
-			'generate_the_math'         => array( $this, 'generate_the_math' ),
+			'get_admin_tools'           => array( $this, 'get_admin_tools' ),
 		);
 	}
 
@@ -260,16 +260,36 @@ class Theme implements Component, Templater {
 	/**
 	 * Do the Math
 	 *
-	 * If a user is NOT logged in, and this got called, re-run the math.
-	 * This is to prevent the math from being run on every page load, since
-	 * we have a lot of caching.
+	 * Creates an editor only button to refresh cache and recalculate a page.
 	 *
 	 * @param  int $post_id
 	 * @return void
 	 */
-	public function generate_the_math( $post_id ): void {
-		if ( ! is_user_logged_in() ) {
-			( new Do_Math() )->make( $post_id );
+	public function get_admin_tools( $post_id ): void {
+		// If you're logged in and can edit posts, you can refresh the scores.
+		if ( is_user_logged_in() && current_user_can( 'edit_posts' ) ) {
+			if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'lwtv-update-math' ) ) {
+				( new Do_Math() )->make( $post_id );
+				sleep( 5 );
+				wp_safe_redirect( get_the_permalink( $post_id ) );
+				exit;
+			}
+
+			?>
+			<section id="editor-tools" class="widget widget_editor_tools">
+				<div class="card">
+					<div class="card-header"><h4>Editor Tools</h4></div>
+					<form id="update_math" name="update_math" method="post">
+						</br>
+						<center><button type="submit" class="btn btn-primary btn-block" id="submit" name="submit">
+							Refresh Data
+						</button></center>
+						<?php wp_nonce_field( 'lwtv-update-math' ); ?>
+						</br>
+					</form>
+				</div>
+			</section>
+			<?php
 		}
 	}
 }

--- a/php/_components/class-theme.php
+++ b/php/_components/class-theme.php
@@ -12,6 +12,7 @@ use LWTV\Theme\Actor_Terms;
 use LWTV\Theme\Content_Warning;
 use LWTV\Theme\Data_Author;
 use LWTV\Theme\Data_Character;
+use LWTV\Theme\Do_Math;
 use LWTV\Theme\List_Characters;
 use LWTV\Theme\Show_Stars;
 use LWTV\Theme\Stats_Symbolicon;
@@ -58,6 +59,7 @@ class Theme implements Component, Templater {
 			'get_actor_dead'            => array( $this, 'get_actor_dead' ),
 			'get_actor_age'             => array( $this, 'get_actor_age' ),
 			'get_actor_birthday'        => array( $this, 'get_actor_birthday' ),
+			'generate_the_math'         => array( $this, 'generate_the_math' ),
 		);
 	}
 
@@ -253,5 +255,15 @@ class Theme implements Component, Templater {
 	 */
 	public function get_actor_age( $actor_id ) {
 		return ( new Actor_Age() )->make( $actor_id );
+	}
+
+	/**
+	 * Do the Math
+	 *
+	 * @param  int $post_id
+	 * @return void
+	 */
+	public function generate_the_math( $post_id ): void {
+		( new Do_Math() )->make( $post_id );
 	}
 }

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -123,6 +123,7 @@ use LWTV\_Helpers\Utils;
  * @method string get_actor_dead( $actor_id )                               \_Components\Theme
  * @method string get_actor_age( $actor_id )                                \_Components\Theme
  * @method string get_actor_birthday( $actor_id )                           \_Components\Theme
+ * @method void   generate_the_math( $post_id )                             \_Components\Theme
  *
  * THIS YEAR
  * @method string get_this_year_display( $year ) \_Components\This_Year

--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -123,7 +123,7 @@ use LWTV\_Helpers\Utils;
  * @method string get_actor_dead( $actor_id )                               \_Components\Theme
  * @method string get_actor_age( $actor_id )                                \_Components\Theme
  * @method string get_actor_birthday( $actor_id )                           \_Components\Theme
- * @method void   generate_the_math( $post_id )                             \_Components\Theme
+ * @method void   get_admin_tools( $post_id )                               \_Components\Theme
  *
  * THIS YEAR
  * @method string get_this_year_display( $year ) \_Components\This_Year

--- a/php/cpts/class-shows.php
+++ b/php/cpts/class-shows.php
@@ -208,7 +208,7 @@ class Shows {
 			'rest_base'           => 'show',
 			'menu_position'       => 5,
 			'menu_icon'           => 'dashicons-video-alt',
-			'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail', 'revisions', 'publicize', 'custom-fields' ),
+			'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail', 'revisions', 'custom-fields' ),
 			'has_archive'         => 'shows',
 			'rewrite'             => array( 'slug' => 'show' ),
 			'delete_with_user'    => false,

--- a/php/grading/class-display.php
+++ b/php/grading/class-display.php
@@ -63,24 +63,6 @@ class Display {
 				<?php
 			}
 		}
-
-		// If you're logged in and can edit posts, you can refresh the scores.
-		if ( is_user_logged_in() && current_user_can( 'edit_posts' ) ) {
-			$post_id = get_the_ID();
-			if ( isset( $_POST['_wpnonce'] ) && wp_verify_nonce( $_POST['_wpnonce'], 'lwtv-update-scores' ) ) {
-				lwtv_plugin()->calculate_show_data( $post_id );
-				sleep( 5 );
-				wp_safe_redirect( get_the_permalink( $post_id ) );
-				exit;
-			}
-
-			?>
-			<form id="update_scores" name="update_scores" method="post">
-				<center><p><br /><input type="submit" value="Refresh Scores" tabindex="6" id="submit" name="submit" /></p></center>
-				<?php wp_nonce_field( 'lwtv-update-scores' ); ?>
-			</form>
-			<?php
-			echo '</center>';
-		}
+		echo '</center>';
 	}
 }

--- a/php/theme/class-do-math.php
+++ b/php/theme/class-do-math.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace LWTV\Theme;
+
+use LWTV\CPTs\Actors\Calculations as Actors;
+use LWTV\CPTs\Shows\Calculations as Shows;
+use LWTV\CPTs\Characters\Calculations as Characters;
+
+class Do_Math {
+	/**
+	 * Do the Math for a specific show/char/actor
+	 *
+	 * @param string  $post_id  Post ID
+	 *
+	 * @return void
+	 */
+	public function make( $post_id ): void {
+		$post_type = get_post_type( $post_id );
+
+		switch ( $post_type ) {
+			case 'post_type_shows':
+				( new Shows() )->do_the_math( $post_id );
+				break;
+			case 'post_type_characters':
+				( new Characters() )->do_the_math( $post_id );
+				break;
+			case 'post_type_actors':
+				( new Actors() )->do_the_math( $post_id );
+				break;
+			default:
+				break;
+		}
+	}
+}

--- a/php/wp-cli/cli-calc.php
+++ b/php/wp-cli/cli-calc.php
@@ -113,4 +113,4 @@ class WP_CLI_LWTV_Calculate {
 	}
 }
 
-\WP_CLI::add_command( 'lwtv calc', 'WP_CLI_LWTV_Calculate', $args );
+\WP_CLI::add_command( 'lwtv calc', 'WP_CLI_LWTV_Calculate' );


### PR DESCRIPTION
This allows us to refresh a page's calculation. For use when:

* Shows are missing characters
* Actors list the wrong character numbers
* Characters have the wrong actor

We'll rarely need it for characters, but in for a penny, in for a pound.

(Also disable publicize for shows since it broke in/around Dec 20)